### PR TITLE
Stats Server: Реализация слоя данных и контрактов API

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -102,6 +102,22 @@
 				<artifactId>jsr305</artifactId>
 				<version>3.0.2</version>
 			</dependency>
+			<dependency>
+				<groupId>com.fasterxml.jackson.core</groupId>
+				<artifactId>jackson-databind</artifactId>
+				<version>2.15.3</version>
+			</dependency>
+			<dependency>
+				<groupId>org.junit.jupiter</groupId>
+				<artifactId>junit-jupiter</artifactId>
+				<version>5.10.1</version>
+				<scope>test</scope>
+			</dependency>
+			<dependency>
+				<groupId>jakarta.validation</groupId>
+				<artifactId>jakarta.validation-api</artifactId>
+				<version>3.1.0</version>
+			</dependency>
 		</dependencies>
 	</dependencyManagement>
 

--- a/stats-service/stats-dto/pom.xml
+++ b/stats-service/stats-dto/pom.xml
@@ -17,7 +17,6 @@
     <dependency>
       <groupId>jakarta.validation</groupId>
       <artifactId>jakarta.validation-api</artifactId>
-      <version>3.1.0</version>
     </dependency>
     <dependency>
       <groupId>org.projectlombok</groupId>
@@ -31,18 +30,14 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.15.3</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>
       <artifactId>jackson-datatype-jsr310</artifactId>
-      <version>2.15.3</version>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>
-      <version>5.10.1</version>
-      <scope>test</scope>
     </dependency>
   </dependencies>
 

--- a/stats-service/stats-dto/src/main/java/ru/practicum/explorewithme/stats/dto/ViewStatsDto.java
+++ b/stats-service/stats-dto/src/main/java/ru/practicum/explorewithme/stats/dto/ViewStatsDto.java
@@ -1,8 +1,12 @@
 package ru.practicum.explorewithme.stats.dto;
 
+import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @Data
+@AllArgsConstructor
+@NoArgsConstructor
 public class ViewStatsDto {
     private String app;
     private String uri;

--- a/stats-service/stats-server/pom.xml
+++ b/stats-service/stats-server/pom.xml
@@ -26,6 +26,10 @@
       <artifactId>spring-boot-starter-actuator</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-test</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.postgresql</groupId>
       <artifactId>postgresql</artifactId>
     </dependency>
@@ -38,6 +42,15 @@
       <groupId>ru.practicum</groupId>
       <artifactId>stats-dto</artifactId>
       <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>postgresql</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>junit-jupiter</artifactId>
     </dependency>
   </dependencies>
 

--- a/stats-service/stats-server/src/main/java/ru/practicum/explorewithme/stats/server/controller/StatsController.java
+++ b/stats-service/stats-server/src/main/java/ru/practicum/explorewithme/stats/server/controller/StatsController.java
@@ -1,17 +1,21 @@
 package ru.practicum.explorewithme.stats.server.controller;
 
+import jakarta.validation.Valid;
+import java.time.LocalDateTime;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
 import ru.practicum.explorewithme.stats.dto.EndpointHitDto;
 import ru.practicum.explorewithme.stats.dto.ViewStatsDto;
-
-import jakarta.validation.Valid;
-import java.time.LocalDateTime;
-import java.util.Collections;
-import java.util.List;
 import ru.practicum.explorewithme.stats.server.service.StatsService;
 
 @RestController
@@ -31,7 +35,9 @@ public class StatsController {
     @PostMapping("/hit")
     @ResponseStatus(HttpStatus.CREATED)
     public void saveHit(@Valid @RequestBody EndpointHitDto endpointHitDto) {
-        log.info("STUB: Received POST /hit request with DTO: {}", endpointHitDto);
+        log.info("Controller: request to save new hit received.");
+        log.debug("Saving new hit: {}", endpointHitDto);
+        statsService.saveHit(endpointHitDto); // Calls the stubbed service method
     }
 
     /**
@@ -57,9 +63,10 @@ public class StatsController {
         @RequestParam(name = "uris", required = false) List<String> uris,
         @RequestParam(name = "unique", defaultValue = "false") Boolean unique) {
 
-        log.info("STUB: Received GET /stats request with params: start={}, end={}, uris={}, unique={}",
+        log.info("Controller: request to retrieve stats received.");
+        log.debug("Request params: start={}, end={}, uris={}, unique={}",
             start, end, uris, unique);
 
-        return Collections.emptyList();
+        return statsService.getStats(start, end, uris, unique);
     }
 }

--- a/stats-service/stats-server/src/main/java/ru/practicum/explorewithme/stats/server/controller/StatsController.java
+++ b/stats-service/stats-server/src/main/java/ru/practicum/explorewithme/stats/server/controller/StatsController.java
@@ -37,7 +37,7 @@ public class StatsController {
     public void saveHit(@Valid @RequestBody EndpointHitDto endpointHitDto) {
         log.info("Controller: request to save new hit received.");
         log.debug("Saving new hit: {}", endpointHitDto);
-        statsService.saveHit(endpointHitDto); // Calls the stubbed service method
+        statsService.saveHit(endpointHitDto);
     }
 
     /**

--- a/stats-service/stats-server/src/main/java/ru/practicum/explorewithme/stats/server/model/EndpointHit.java
+++ b/stats-service/stats-server/src/main/java/ru/practicum/explorewithme/stats/server/model/EndpointHit.java
@@ -1,7 +1,57 @@
 package ru.practicum.explorewithme.stats.server.model;
 
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import java.util.Objects;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@Entity
+@Table(name = "endpoint_hits")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
 public class EndpointHit {
 
-    // TODO: endpoint hit model
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
 
+    @Column(name = "app", nullable = false, length = 32)
+    private String app;
+
+    @Column(name = "uri", nullable = false, length = 128)
+    private String uri;
+
+    @Column(name = "ip", nullable = false, length = 16)
+    private String ip;
+
+    @Column(name = "timestamp", nullable = false)
+    private LocalDateTime timestamp;
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        return id != null && id.equals(((EndpointHit) o).getId());
+    }
+
+    @Override
+    public int hashCode() {
+        return id != null ? Objects.hash(id) : getClass().hashCode();
+    }
 }

--- a/stats-service/stats-server/src/main/java/ru/practicum/explorewithme/stats/server/repository/StatsRepository.java
+++ b/stats-service/stats-server/src/main/java/ru/practicum/explorewithme/stats/server/repository/StatsRepository.java
@@ -1,0 +1,39 @@
+package ru.practicum.explorewithme.stats.server.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+import ru.practicum.explorewithme.stats.dto.ViewStatsDto;
+import ru.practicum.explorewithme.stats.server.model.EndpointHit;
+
+import java.time.LocalDateTime;
+import java.util.Collection;
+import java.util.List;
+
+@Repository
+public interface StatsRepository extends JpaRepository<EndpointHit, Long> {
+
+    @Query("SELECT new ru.practicum.explorewithme.stats.dto.ViewStatsDto(eh.app, eh.uri, COUNT(eh.ip)) " +
+        "FROM EndpointHit eh " +
+        "WHERE eh.timestamp BETWEEN :start AND :end " +
+        "AND (:uris IS NULL OR eh.uri IN :uris) " +
+        "GROUP BY eh.app, eh.uri " +
+        "ORDER BY COUNT(eh.ip) DESC")
+    List<ViewStatsDto> findStats(
+        @Param("start") LocalDateTime start,
+        @Param("end") LocalDateTime end,
+        @Param("uris") Collection<String> uris);
+
+    @Query("SELECT new ru.practicum.explorewithme.stats.dto.ViewStatsDto(eh.app, eh.uri, COUNT(DISTINCT eh.ip)) " +
+        "FROM EndpointHit eh " +
+        "WHERE eh.timestamp BETWEEN :start AND :end " +
+        "AND (:uris IS NULL OR eh.uri IN :uris) " +
+        "GROUP BY eh.app, eh.uri " +
+        "ORDER BY COUNT(DISTINCT eh.ip) DESC")
+    List<ViewStatsDto> findUniqueStats(
+        @Param("start") LocalDateTime start,
+        @Param("end") LocalDateTime end,
+        @Param("uris") Collection<String> uris);
+
+}

--- a/stats-service/stats-server/src/main/java/ru/practicum/explorewithme/stats/server/service/StatsService.java
+++ b/stats-service/stats-server/src/main/java/ru/practicum/explorewithme/stats/server/service/StatsService.java
@@ -1,10 +1,29 @@
 package ru.practicum.explorewithme.stats.server.service;
 
-import org.springframework.stereotype.Service;
+import ru.practicum.explorewithme.stats.dto.EndpointHitDto;
+import ru.practicum.explorewithme.stats.dto.ViewStatsDto;
 
-@Service
-public class StatsService {
+import java.time.LocalDateTime;
+import java.util.List;
 
-    // TODO: stats service
+public interface StatsService {
+
+    /**
+     * Сохраняет информацию о запросе к эндпоинту.
+     *
+     * @param endpointHitDto DTO с информацией о запросе.
+     */
+    void saveHit(EndpointHitDto endpointHitDto);
+
+    /**
+     * Возвращает статистику по посещениям за указанный период.
+     *
+     * @param start  дата и время начала диапазона для статистики.
+     * @param end    дата и время конца диапазона для статистики.
+     * @param uris   список URI, для которых нужна статистика (может быть null или пустым для всех URI).
+     * @param unique true, если нужны только уникальные по IP посещения, false иначе.
+     * @return список DTO {@link ViewStatsDto} со статистикой.
+     **/
+    List<ViewStatsDto> getStats(LocalDateTime start, LocalDateTime end, List<String> uris, boolean unique);
 
 }

--- a/stats-service/stats-server/src/main/java/ru/practicum/explorewithme/stats/server/service/StatsService.java
+++ b/stats-service/stats-server/src/main/java/ru/practicum/explorewithme/stats/server/service/StatsService.java
@@ -12,7 +12,7 @@ public interface StatsService {
      * Сохраняет информацию о запросе к эндпоинту.
      *
      * @param endpointHitDto DTO с информацией о запросе.
-     */
+     **/
     void saveHit(EndpointHitDto endpointHitDto);
 
     /**

--- a/stats-service/stats-server/src/main/java/ru/practicum/explorewithme/stats/server/service/StatsServiceImpl.java
+++ b/stats-service/stats-server/src/main/java/ru/practicum/explorewithme/stats/server/service/StatsServiceImpl.java
@@ -1,0 +1,33 @@
+package ru.practicum.explorewithme.stats.server.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import ru.practicum.explorewithme.stats.dto.EndpointHitDto;
+import ru.practicum.explorewithme.stats.dto.ViewStatsDto;
+
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
+import ru.practicum.explorewithme.stats.server.repository.StatsRepository;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+@SuppressWarnings("unused")
+public class StatsServiceImpl implements StatsService {
+
+    private final StatsRepository statsRepository;
+
+    @Override
+    public void saveHit(EndpointHitDto endpointHitDto) {
+        log.warn("STUB IMPLEMENTATION: StatsServiceImpl.saveHit called with DTO: {}", endpointHitDto);
+    }
+
+    @Override
+    public List<ViewStatsDto> getStats(LocalDateTime start, LocalDateTime end, List<String> uris, boolean unique) {
+        log.warn("STUB IMPLEMENTATION: StatsServiceImpl.getStats called with params: start={}, end={}, uris={}, unique={}",
+            start, end, uris, unique);
+        return Collections.emptyList();
+    }
+}

--- a/stats-service/stats-server/src/main/resources/application-local.yaml
+++ b/stats-service/stats-server/src/main/resources/application-local.yaml
@@ -3,3 +3,13 @@ spring:
     url: jdbc:postgresql://localhost:6543/ewm_stats_db
     username: stats_user
     password: stats_password
+  jpa:
+    hibernate:
+      ddl-auto: update
+      show-sql: true
+    properties:
+      hibernate.format_sql: true
+  logging:
+    level:
+      org.hibernate.SQL: DEBUG
+      org.hibernate.type.descriptor.sql.BasicBinder: TRACE

--- a/stats-service/stats-server/src/test/java/ru/practicum/explorewithme/stats/server/repository/StatsRepositoryTest.java
+++ b/stats-service/stats-server/src/test/java/ru/practicum/explorewithme/stats/server/repository/StatsRepositoryTest.java
@@ -1,0 +1,178 @@
+package ru.practicum.explorewithme.stats.server.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+import ru.practicum.explorewithme.stats.dto.ViewStatsDto;
+import ru.practicum.explorewithme.stats.server.model.EndpointHit;
+
+@DataJpaTest
+@Testcontainers
+@DisplayName("Stats Repository DataJpa Tests")
+public class StatsRepositoryTest {
+
+    // Настройка контейнера с тестовой БД
+    @Container
+    private static final PostgreSQLContainer<?> postgresqlContainer = new PostgreSQLContainer<>(
+        DockerImageName.parse("postgres:16.1"));
+
+    @DynamicPropertySource
+    static void postgresqlProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", postgresqlContainer::getJdbcUrl);
+        registry.add("spring.datasource.username", postgresqlContainer::getUsername);
+        registry.add("spring.datasource.password", postgresqlContainer::getPassword);
+        registry.add("spring.jpa.hibernate.ddl-auto", () -> "create");
+    }
+
+    @Autowired
+    private StatsRepository statsRepository; // Тестируемый репозиторий
+
+    @Autowired
+    private TestEntityManager entityManager;
+
+    // Тестовые данные для EndpointHit
+    private EndpointHit hit1, hit2, hit3, hit4, hit5;
+    private final LocalDateTime now = LocalDateTime.now();
+
+    @BeforeEach
+    void setUp() {
+        hit1 = new EndpointHit(null, "app1", "/uri1", "192.168.0.1", now.minusHours(1));
+        hit2 = new EndpointHit(null, "app1", "/uri1", "192.168.0.2", now.minusMinutes(30));
+        hit3 = new EndpointHit(null, "app1", "/uri1", "192.168.0.1", now.minusMinutes(10)); // Повторный IP для /uri1
+        hit4 = new EndpointHit(null, "app2", "/uri2", "192.168.0.3", now.minusHours(2));
+        hit5 = new EndpointHit(null, "app1", "/uri3", "192.168.0.1", now.minusMinutes(5)); // Другой URI, но IP как у hit1
+
+        statsRepository.saveAll(List.of(hit1, hit2, hit3, hit4, hit5));
+    }
+
+    @AfterEach
+    void tearDown() {
+        statsRepository.deleteAll();
+    }
+
+    @Nested
+    @DisplayName("findStats (статистика по общему количеству хитов)")
+    class FindStatsTest {
+
+        @Test
+        @DisplayName("Должен вернуть корректное общее количество хитов для указанных URI в заданном временном диапазоне")
+        void findStats_whenUrisProvided_shouldReturnCorrectStats() {
+            LocalDateTime start = now.minusHours(3);
+            LocalDateTime end = now.plusHours(1);
+            List<String> uris = List.of("/uri1", "/uri3");
+
+            List<ViewStatsDto> result = statsRepository.findStats(start, end, uris);
+
+            assertThat(result).hasSize(2); // Ожидаем статистику для двух URI: /uri1 и /uri3
+
+            // Проверка статистики для /uri1
+            ViewStatsDto statsUri1 = result.stream().filter(s -> s.getUri().equals("/uri1")).findFirst().orElse(null);
+            assertThat(statsUri1).isNotNull();
+            assertThat(statsUri1.getApp()).isEqualTo("app1");
+            assertThat(statsUri1.getHits()).isEqualTo(3L); // hit1, hit2, hit3 для /uri1
+
+            // Проверка статистики для /uri3
+            ViewStatsDto statsUri3 = result.stream().filter(s -> s.getUri().equals("/uri3")).findFirst().orElse(null);
+            assertThat(statsUri3).isNotNull();
+            assertThat(statsUri3.getApp()).isEqualTo("app1");
+            assertThat(statsUri3.getHits()).isEqualTo(1L); // hit5 для /uri3
+        }
+
+        @Test
+        @DisplayName("Должен вернуть корректное общее количество хитов для всех URI в заданном временном диапазоне, если URI не указаны")
+        void findStats_whenUrisNotProvided_shouldReturnStatsForAllUris() {
+            LocalDateTime start = now.minusHours(3);
+            LocalDateTime end = now.plusHours(1);
+
+            List<ViewStatsDto> result = statsRepository.findStats(start, end, null); // URI не указаны
+
+            assertThat(result).hasSize(3); // Ожидаем статистику для трех уникальных URI: /uri1, /uri2, /uri3
+
+            // Результат отсортирован по app, затем по URI, затем по количеству хитов (здесь /uri1 первый)
+            assertThat(result.getFirst().getUri()).isEqualTo("/uri1"); // /uri1 имеет 3 хита
+            assertThat(result.getFirst().getHits()).isEqualTo(3L);
+
+            // Проверка наличия и корректности данных для /uri2 и /uri3
+            boolean foundUri2 = result.stream().anyMatch(s -> s.getUri().equals("/uri2") && s.getHits() == 1L); // hit4 для /uri2
+            boolean foundUri3 = result.stream().anyMatch(s -> s.getUri().equals("/uri3") && s.getHits() == 1L); // hit5 для /uri3
+            assertThat(foundUri2).isTrue();
+            assertThat(foundUri3).isTrue();
+        }
+
+        @Test
+        @DisplayName("Должен вернуть пустой список, если временной диапазон не содержит хитов")
+        void findStats_whenTimeRangeExcludesData_shouldReturnEmptyList() {
+            // Задаем временной диапазон, который гарантированно не содержит тестовых данных
+            LocalDateTime start = now.plusHours(1);
+            LocalDateTime end = now.plusHours(2);
+
+            List<ViewStatsDto> result = statsRepository.findStats(start, end, null);
+            assertThat(result).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("findUniqueStats (статистика по уникальным IP)")
+    class FindUniqueStatsTest {
+
+        @Test
+        @DisplayName("Должен вернуть корректное количество уникальных хитов (по IP) для указанных URI в заданном временном диапазоне")
+        void findUniqueStats_whenUrisProvided_shouldReturnCorrectUniqueStats() {
+            LocalDateTime start = now.minusHours(3);
+            LocalDateTime end = now.plusHours(1);
+            List<String> uris = List.of("/uri1"); // Только для /uri1
+
+            List<ViewStatsDto> result = statsRepository.findUniqueStats(start, end, uris);
+
+            assertThat(result).hasSize(1); // Ожидаем статистику только для /uri1
+            ViewStatsDto statsUri1 = result.getFirst();
+            assertThat(statsUri1.getApp()).isEqualTo("app1");
+            assertThat(statsUri1.getUri()).isEqualTo("/uri1");
+            assertThat(statsUri1.getHits()).isEqualTo(2L); // Уникальные IP для /uri1: 192.168.0.1, 192.168.0.2
+        }
+
+        @Test
+        @DisplayName("Должен вернуть корректное количество уникальных хитов (по IP) для всех URI в заданном временном диапазоне, если URI не указаны")
+        void findUniqueStats_whenUrisNotProvided_shouldReturnUniqueStatsForAllUris() {
+            LocalDateTime start = now.minusHours(3);
+            LocalDateTime end = now.plusHours(1);
+
+            List<ViewStatsDto> result = statsRepository.findUniqueStats(start, end, null); // URI не указаны
+
+            assertThat(result).hasSize(3); // Ожидаем статистику для трех уникальных URI
+
+            // Проверка статистики для /uri1
+            ViewStatsDto statsUri1 = result.stream().filter(s -> s.getUri().equals("/uri1")).findFirst().orElse(null);
+            assertThat(statsUri1).isNotNull();
+            assertThat(statsUri1.getApp()).isEqualTo("app1");
+            assertThat(statsUri1.getHits()).isEqualTo(2L); // Уникальные IP для /uri1: 192.168.0.1, 192.168.0.2
+
+            // Проверка статистики для /uri2
+            ViewStatsDto statsUri2 = result.stream().filter(s -> s.getUri().equals("/uri2")).findFirst().orElse(null);
+            assertThat(statsUri2).isNotNull();
+            assertThat(statsUri2.getApp()).isEqualTo("app2");
+            assertThat(statsUri2.getHits()).isEqualTo(1L); // Уникальный IP для /uri2: 192.168.0.3
+
+            // Проверка статистики для /uri3
+            ViewStatsDto statsUri3 = result.stream().filter(s -> s.getUri().equals("/uri3")).findFirst().orElse(null);
+            assertThat(statsUri3).isNotNull();
+            assertThat(statsUri3.getApp()).isEqualTo("app1");
+            assertThat(statsUri3.getHits()).isEqualTo(1L); // Уникальный IP для /uri3: 192.168.0.1
+        }
+    }
+}


### PR DESCRIPTION
## Описание

Этот PR закладывает основу для сервиса статистики (`stats-server`), реализуя:
1.  Слой данных:
    *   JPA-сущность `EndpointHit` для сохранения информации о запросах.
    *   Интерфейс `StatsRepository` (Spring Data JPA) с кастомными JPQL-запросами для получения агрегированной статистики. Запросы протестированы с использованием `@DataJpaTest` и Testcontainers (PostgreSQL).
2.  Контракты API и сервиса:
    *   Интерфейс `StatsService`, определяющий методы для сохранения хитов и получения статистики.
    *   Заглушка (stub) реализации `StatsServiceImpl`, которая на данный момент только логирует вызовы и возвращает значения по умолчанию.
    *   Обновленный `StatsController`, который теперь внедряет и вызывает (заглушенный) `StatsService`.

Данный PR подготавливает `stats-server` к последующей реализации полной бизнес-логики в сервисном слое.

---
### Для ревьюера

*   Пожалуйста, обратите внимание на корректность определения сущности `EndpointHit` и JPQL-запросов в `StatsRepository`.
*   Тесты для `StatsRepository` (`StatsRepositoryTest`) используют Testcontainers и должны проходить.
*   Логика в `StatsServiceImpl` намеренно является заглушкой и будет реализована в следующем PR.
*   Контроллер `StatsController` теперь корректно вызывает методы сервиса (пока еще заглушенного).

---
### Как тестировать локально

1.  Собрать проект: `mvn clean install`
2.  Запустить сервис локально (профиль `local`): через IntelliJ IDEA Run Configuration "stat-local" (требуется локальный PostgreSQL или запущенный `docker-compose up stats-db`).
3.  Проверить эндпоинты через Postman:
    *   `POST /hit` (тело: `EndpointHitDto`) - должен вернуть `201 Created`. В логах сервера будет информация о вызове заглушки сервиса.
    *   `GET /stats` (с параметрами `start`, `end`, `uris`, `unique`) - должен вернуть `200 OK` с пустым JSON-массивом `[]`. В логах сервера будет информация о вызове заглушки сервиса.