### PR TITLE
Admin API: Реализация поиска и фильтрации событий

### DIFF
--- a/main-service/pom.xml
+++ b/main-service/pom.xml
@@ -51,6 +51,7 @@
     <dependency>
       <groupId>com.querydsl</groupId>
       <artifactId>querydsl-jpa</artifactId>
+      <classifier>jakarta</classifier>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
@@ -63,6 +64,18 @@
     <dependency>
       <groupId>org.mapstruct</groupId>
       <artifactId>mapstruct</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>testcontainers</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>junit-jupiter</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>postgresql</artifactId>
     </dependency>
   </dependencies>
 

--- a/main-service/pom.xml
+++ b/main-service/pom.xml
@@ -63,34 +63,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <configuration>
-          <source>${java.version}</source>
-          <target>${java.version}</target>
-          <annotationProcessorPaths>
-            <path>
-              <groupId>org.projectlombok</groupId>
-              <artifactId>lombok</artifactId>
-              <version>${lombok.version}</version>
-            </path>
-            <path>
-              <groupId>com.querydsl</groupId>
-              <artifactId>querydsl-apt</artifactId>
-              <version>${querydsl.version}</version>
-              <classifier>jakarta</classifier>
-            </path>
-            <path>
-              <groupId>jakarta.persistence</groupId>
-              <artifactId>jakarta.persistence-api</artifactId>
-              <version>3.1.0</version>
-            </path>
-            <path>
-              <groupId>jakarta.annotation</groupId>
-              <artifactId>jakarta.annotation-api</artifactId>
-              <version>2.1.1</version>
-            </path>
-          </annotationProcessorPaths>
-          <generatedSourcesDirectory>${project.build.directory}/generated-sources/annotations</generatedSourcesDirectory>
-        </configuration>
       </plugin>
       <plugin>
         <groupId>org.springframework.boot</groupId>

--- a/main-service/pom.xml
+++ b/main-service/pom.xml
@@ -57,6 +57,10 @@
       <artifactId>spring-boot-starter-validation</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-test</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.mapstruct</groupId>
       <artifactId>mapstruct</artifactId>
     </dependency>

--- a/main-service/pom.xml
+++ b/main-service/pom.xml
@@ -56,6 +56,10 @@
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-validation</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.mapstruct</groupId>
+      <artifactId>mapstruct</artifactId>
+    </dependency>
   </dependencies>
 
   <build>

--- a/main-service/pom.xml
+++ b/main-service/pom.xml
@@ -45,6 +45,14 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>com.querydsl</groupId>
+      <artifactId>querydsl-apt</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.querydsl</groupId>
+      <artifactId>querydsl-jpa</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-validation</artifactId>
     </dependency>
@@ -52,6 +60,38 @@
 
   <build>
     <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <source>${java.version}</source>
+          <target>${java.version}</target>
+          <annotationProcessorPaths>
+            <path>
+              <groupId>org.projectlombok</groupId>
+              <artifactId>lombok</artifactId>
+              <version>${lombok.version}</version>
+            </path>
+            <path>
+              <groupId>com.querydsl</groupId>
+              <artifactId>querydsl-apt</artifactId>
+              <version>${querydsl.version}</version>
+              <classifier>jakarta</classifier>
+            </path>
+            <path>
+              <groupId>jakarta.persistence</groupId>
+              <artifactId>jakarta.persistence-api</artifactId>
+              <version>3.1.0</version>
+            </path>
+            <path>
+              <groupId>jakarta.annotation</groupId>
+              <artifactId>jakarta.annotation-api</artifactId>
+              <version>2.1.1</version>
+            </path>
+          </annotationProcessorPaths>
+          <generatedSourcesDirectory>${project.build.directory}/generated-sources/annotations</generatedSourcesDirectory>
+        </configuration>
+      </plugin>
       <plugin>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-maven-plugin</artifactId>

--- a/main-service/src/main/java/ru/practicum/explorewithme/main/controller/admin/AdminEventController.java
+++ b/main-service/src/main/java/ru/practicum/explorewithme/main/controller/admin/AdminEventController.java
@@ -1,0 +1,77 @@
+package ru.practicum.explorewithme.main.controller.admin;
+
+import static ru.practicum.explorewithme.common.constants.DateTimeConstants.DATE_TIME_FORMAT_PATTERN;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.HttpStatus;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+import ru.practicum.explorewithme.main.dto.EventFullDto;
+import ru.practicum.explorewithme.main.models.EventState;
+import ru.practicum.explorewithme.main.service.EventService;
+
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.PositiveOrZero;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@RestController
+@RequestMapping("/admin/events")
+@RequiredArgsConstructor
+@Validated
+@Slf4j
+public class AdminEventController {
+
+    private final EventService eventService;
+    private static final String DATETIME_FORMAT = DATE_TIME_FORMAT_PATTERN;
+
+    /**
+     * Поиск событий администратором.
+     * Эндпоинт возвращает полную информацию обо всех событиях подходящих под переданные условия.
+     * В случае, если по заданным фильтрам не найдено ни одного события, возвращает пустой список.
+     *
+     * @param users      список id пользователей, чьи события нужно найти
+     * @param states     список состояний в которых находятся искомые события
+     * @param categories список id категорий в которых будет вестись поиск
+     * @param rangeStart дата и время не раньше которых должно произойти событие
+     * @param rangeEnd   дата и время не позже которых должно произойти событие
+     * @param from       количество событий, которые нужно пропустить для формирования текущего набора
+     * @param size       количество событий в наборе
+     * @return Список EventFullDto
+     */
+    @GetMapping
+    @ResponseStatus(HttpStatus.OK)
+    public List<EventFullDto> searchEventsAdmin(
+        @RequestParam(name = "users", required = false) List<Long> users,
+        @RequestParam(name = "states", required = false) List<EventState> states,
+        @RequestParam(name = "categories", required = false) List<Long> categories,
+        @RequestParam(name = "rangeStart", required = false)
+        @DateTimeFormat(pattern = DATETIME_FORMAT) LocalDateTime rangeStart,
+        @RequestParam(name = "rangeEnd", required = false)
+        @DateTimeFormat(pattern = DATETIME_FORMAT) LocalDateTime rangeEnd,
+        @RequestParam(name = "from", defaultValue = "0") @PositiveOrZero int from,
+        @RequestParam(name = "size", defaultValue = "10") @Positive int size) {
+
+        log.info("Admin: Received request to search events with params: users={}, states={}, categories={}, " +
+                "rangeStart={}, rangeEnd={}, from={}, size={}",
+            users, states, categories, rangeStart, rangeEnd, from, size);
+
+        List<EventFullDto> foundEvents = eventService.getEventsAdmin(
+            users,
+            states,
+            categories,
+            rangeStart,
+            rangeEnd,
+            from,
+            size
+        );
+        log.info("Admin: Found {} events for the given criteria.", foundEvents.size());
+        return foundEvents;
+    }
+
+    // TODO: Добавить PATCH /admin/events/{eventId} для модерации событий
+    // (Задача: ADMIN-EVENTS: Реализация модерации событий (публикация/отклонение))
+
+}

--- a/main-service/src/main/java/ru/practicum/explorewithme/main/controller/admin/AdminEventController.java
+++ b/main-service/src/main/java/ru/practicum/explorewithme/main/controller/admin/AdminEventController.java
@@ -9,7 +9,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import ru.practicum.explorewithme.main.dto.EventFullDto;
-import ru.practicum.explorewithme.main.models.EventState;
+import ru.practicum.explorewithme.main.model.EventState;
 import ru.practicum.explorewithme.main.service.EventService;
 
 import jakarta.validation.constraints.Positive;

--- a/main-service/src/main/java/ru/practicum/explorewithme/main/controller/admin/AdminEventController.java
+++ b/main-service/src/main/java/ru/practicum/explorewithme/main/controller/admin/AdminEventController.java
@@ -16,6 +16,7 @@ import jakarta.validation.constraints.Positive;
 import jakarta.validation.constraints.PositiveOrZero;
 import java.time.LocalDateTime;
 import java.util.List;
+import ru.practicum.explorewithme.main.service.params.AdminEventSearchParams;
 
 @RestController
 @RequestMapping("/admin/events")
@@ -58,12 +59,11 @@ public class AdminEventController {
                 "rangeStart={}, rangeEnd={}, from={}, size={}",
             users, states, categories, rangeStart, rangeEnd, from, size);
 
+        AdminEventSearchParams params = AdminEventSearchParams.builder().users(users).states(states)
+            .categories(categories).rangeStart(rangeStart).rangeEnd(rangeEnd).build();
+
         List<EventFullDto> foundEvents = eventService.getEventsAdmin(
-            users,
-            states,
-            categories,
-            rangeStart,
-            rangeEnd,
+            params,
             from,
             size
         );

--- a/main-service/src/main/java/ru/practicum/explorewithme/main/dto/CategoryDto.java
+++ b/main-service/src/main/java/ru/practicum/explorewithme/main/dto/CategoryDto.java
@@ -1,0 +1,17 @@
+package ru.practicum.explorewithme.main.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+// TODO: полноценная реализация CategoryDto
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CategoryDto {
+    private Long id;
+    private String name;
+}

--- a/main-service/src/main/java/ru/practicum/explorewithme/main/dto/EventFullDto.java
+++ b/main-service/src/main/java/ru/practicum/explorewithme/main/dto/EventFullDto.java
@@ -1,0 +1,34 @@
+package ru.practicum.explorewithme.main.dto;
+
+import static ru.practicum.explorewithme.common.constants.DateTimeConstants.DATE_TIME_FORMAT_PATTERN;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.Data;
+import ru.practicum.explorewithme.main.models.EventState;
+import ru.practicum.explorewithme.main.models.Location;
+
+@Data
+@Builder
+public class EventFullDto {
+    private Long id;
+    private String annotation;
+    private CategoryDto category;
+    private Long confirmedRequests;
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = DATE_TIME_FORMAT_PATTERN)
+    private LocalDateTime createdOn;
+    private String description;
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = DATE_TIME_FORMAT_PATTERN)
+    private LocalDateTime eventDate;
+    private UserShortDto initiator;
+    private Location location;
+    private boolean paid;
+    private int participantLimit;
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = DATE_TIME_FORMAT_PATTERN)
+    private LocalDateTime publishedOn;
+    private boolean requestModeration;
+    private EventState state;
+    private String title;
+    private Long views;
+}

--- a/main-service/src/main/java/ru/practicum/explorewithme/main/dto/EventFullDto.java
+++ b/main-service/src/main/java/ru/practicum/explorewithme/main/dto/EventFullDto.java
@@ -6,8 +6,8 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import java.time.LocalDateTime;
 import lombok.Builder;
 import lombok.Data;
-import ru.practicum.explorewithme.main.models.EventState;
-import ru.practicum.explorewithme.main.models.Location;
+import ru.practicum.explorewithme.main.model.EventState;
+import ru.practicum.explorewithme.main.model.Location;
 
 @Data
 @Builder

--- a/main-service/src/main/java/ru/practicum/explorewithme/main/dto/UserShortDto.java
+++ b/main-service/src/main/java/ru/practicum/explorewithme/main/dto/UserShortDto.java
@@ -1,0 +1,17 @@
+package ru.practicum.explorewithme.main.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+// TODO: полноценная реализация UserShortDto
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserShortDto {
+    private Long id;
+    private String name;
+}

--- a/main-service/src/main/java/ru/practicum/explorewithme/main/mapper/CategoryMapper.java
+++ b/main-service/src/main/java/ru/practicum/explorewithme/main/mapper/CategoryMapper.java
@@ -2,7 +2,7 @@ package ru.practicum.explorewithme.main.mapper;
 
 import org.mapstruct.Mapper;
 import ru.practicum.explorewithme.main.dto.CategoryDto;
-import ru.practicum.explorewithme.main.models.Category;
+import ru.practicum.explorewithme.main.model.Category;
 
 @Mapper(componentModel = "spring")
 public interface CategoryMapper {

--- a/main-service/src/main/java/ru/practicum/explorewithme/main/mapper/CategoryMapper.java
+++ b/main-service/src/main/java/ru/practicum/explorewithme/main/mapper/CategoryMapper.java
@@ -1,0 +1,10 @@
+package ru.practicum.explorewithme.main.mapper;
+
+import org.mapstruct.Mapper;
+import ru.practicum.explorewithme.main.dto.CategoryDto;
+import ru.practicum.explorewithme.main.models.Category;
+
+@Mapper(componentModel = "spring")
+public interface CategoryMapper {
+    CategoryDto toDto(Category category);
+}

--- a/main-service/src/main/java/ru/practicum/explorewithme/main/mapper/EventMapper.java
+++ b/main-service/src/main/java/ru/practicum/explorewithme/main/mapper/EventMapper.java
@@ -4,7 +4,7 @@ import java.util.List;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import ru.practicum.explorewithme.main.dto.EventFullDto;
-import ru.practicum.explorewithme.main.models.Event;
+import ru.practicum.explorewithme.main.model.Event;
 
 @Mapper(componentModel = "spring", uses = {CategoryMapper.class, UserMapper.class})
 public interface EventMapper {

--- a/main-service/src/main/java/ru/practicum/explorewithme/main/mapper/EventMapper.java
+++ b/main-service/src/main/java/ru/practicum/explorewithme/main/mapper/EventMapper.java
@@ -17,6 +17,3 @@ public interface EventMapper {
 
     List<EventFullDto> toEventFullDtoList(List<Event> events);
 }
-
-
-

--- a/main-service/src/main/java/ru/practicum/explorewithme/main/mapper/EventMapper.java
+++ b/main-service/src/main/java/ru/practicum/explorewithme/main/mapper/EventMapper.java
@@ -1,60 +1,22 @@
 package ru.practicum.explorewithme.main.mapper; // Пример пакета
 
+import java.util.List;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
-import org.mapstruct.Named;
-import org.mapstruct.factory.Mappers;
-import ru.practicum.explorewithme.main.dto.CategoryDto;
-import ru.practicum.explorewithme.main.models.Category;
 import ru.practicum.explorewithme.main.dto.EventFullDto;
 import ru.practicum.explorewithme.main.models.Event;
-import ru.practicum.explorewithme.main.dto.UserShortDto;
-import ru.practicum.explorewithme.main.models.User;
 
-import java.util.List;
-
-// componentModel = "spring" позволит внедрять маппер как бин
 @Mapper(componentModel = "spring", uses = {CategoryMapper.class, UserMapper.class})
 public interface EventMapper {
 
-    // Если CategoryMapper и UserMapper определены и используются (см. ниже)
-    @Mapping(source = "category", target = "category") // MapStruct сам вызовет CategoryMapper.toDto(Category)
-    @Mapping(source = "initiator", target = "initiator") // MapStruct сам вызовет UserMapper.toShortDto(User)
+    @Mapping(source = "category", target = "category")
+    @Mapping(source = "initiator", target = "initiator")
     @Mapping(target = "confirmedRequests", expression = "java(0L)") // Временная заглушка
     @Mapping(target = "views", expression = "java(0L)") // Временная заглушка
     EventFullDto toEventFullDto(Event event);
 
     List<EventFullDto> toEventFullDtoList(List<Event> events);
-
-    // Если вы хотите мапить связанные сущности прямо здесь:
-    // @Mapping(source = "event.category", target = "category", qualifiedByName = "categoryToCategoryDto")
-    // @Mapping(source = "event.initiator", target = "initiator", qualifiedByName = "userToUserShortDto")
-    // EventFullDto toEventFullDtoManualSubMapping(Event event);
-
-    // @Named("categoryToCategoryDto")
-    // default CategoryDto categoryToCategoryDto(Category category) {
-    //     if (category == null) return null;
-    //     return CategoryDto.builder().id(category.getId()).name(category.getName()).build();
-    // }
-
-    // @Named("userToUserShortDto")
-    // default UserShortDto userToUserShortDto(User user) {
-    //     if (user == null) return null;
-    //     return UserShortDto.builder().id(user.getId()).name(user.getName()).build();
-    // }
 }
 
-// Отдельный маппер для Category (если он используется во многих местах)
-// Либо можно было бы использовать default методы или @Named методы в EventMapper, как закомментировано выше.
-@Mapper(componentModel = "spring")
-interface CategoryMapper {
-    CategoryDto toDto(Category category);
-    // Category toEntity(CategoryDto categoryDto); // Если нужен обратный маппинг
-}
 
-// Отдельный маппер для User
-@Mapper(componentModel = "spring")
-interface UserMapper {
-    UserShortDto toShortDto(User user);
-    // User toEntity(UserShortDto userShortDto); // Если нужен обратный маппинг
-}
+

--- a/main-service/src/main/java/ru/practicum/explorewithme/main/mapper/EventMapper.java
+++ b/main-service/src/main/java/ru/practicum/explorewithme/main/mapper/EventMapper.java
@@ -1,0 +1,60 @@
+package ru.practicum.explorewithme.main.mapper; // Пример пакета
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.Named;
+import org.mapstruct.factory.Mappers;
+import ru.practicum.explorewithme.main.dto.CategoryDto;
+import ru.practicum.explorewithme.main.models.Category;
+import ru.practicum.explorewithme.main.dto.EventFullDto;
+import ru.practicum.explorewithme.main.models.Event;
+import ru.practicum.explorewithme.main.dto.UserShortDto;
+import ru.practicum.explorewithme.main.models.User;
+
+import java.util.List;
+
+// componentModel = "spring" позволит внедрять маппер как бин
+@Mapper(componentModel = "spring", uses = {CategoryMapper.class, UserMapper.class})
+public interface EventMapper {
+
+    // Если CategoryMapper и UserMapper определены и используются (см. ниже)
+    @Mapping(source = "category", target = "category") // MapStruct сам вызовет CategoryMapper.toDto(Category)
+    @Mapping(source = "initiator", target = "initiator") // MapStruct сам вызовет UserMapper.toShortDto(User)
+    @Mapping(target = "confirmedRequests", expression = "java(0L)") // Временная заглушка
+    @Mapping(target = "views", expression = "java(0L)") // Временная заглушка
+    EventFullDto toEventFullDto(Event event);
+
+    List<EventFullDto> toEventFullDtoList(List<Event> events);
+
+    // Если вы хотите мапить связанные сущности прямо здесь:
+    // @Mapping(source = "event.category", target = "category", qualifiedByName = "categoryToCategoryDto")
+    // @Mapping(source = "event.initiator", target = "initiator", qualifiedByName = "userToUserShortDto")
+    // EventFullDto toEventFullDtoManualSubMapping(Event event);
+
+    // @Named("categoryToCategoryDto")
+    // default CategoryDto categoryToCategoryDto(Category category) {
+    //     if (category == null) return null;
+    //     return CategoryDto.builder().id(category.getId()).name(category.getName()).build();
+    // }
+
+    // @Named("userToUserShortDto")
+    // default UserShortDto userToUserShortDto(User user) {
+    //     if (user == null) return null;
+    //     return UserShortDto.builder().id(user.getId()).name(user.getName()).build();
+    // }
+}
+
+// Отдельный маппер для Category (если он используется во многих местах)
+// Либо можно было бы использовать default методы или @Named методы в EventMapper, как закомментировано выше.
+@Mapper(componentModel = "spring")
+interface CategoryMapper {
+    CategoryDto toDto(Category category);
+    // Category toEntity(CategoryDto categoryDto); // Если нужен обратный маппинг
+}
+
+// Отдельный маппер для User
+@Mapper(componentModel = "spring")
+interface UserMapper {
+    UserShortDto toShortDto(User user);
+    // User toEntity(UserShortDto userShortDto); // Если нужен обратный маппинг
+}

--- a/main-service/src/main/java/ru/practicum/explorewithme/main/mapper/UserMapper.java
+++ b/main-service/src/main/java/ru/practicum/explorewithme/main/mapper/UserMapper.java
@@ -2,7 +2,7 @@ package ru.practicum.explorewithme.main.mapper;
 
 import org.mapstruct.Mapper;
 import ru.practicum.explorewithme.main.dto.UserShortDto;
-import ru.practicum.explorewithme.main.models.User;
+import ru.practicum.explorewithme.main.model.User;
 
 @Mapper(componentModel = "spring")
 public interface UserMapper {

--- a/main-service/src/main/java/ru/practicum/explorewithme/main/mapper/UserMapper.java
+++ b/main-service/src/main/java/ru/practicum/explorewithme/main/mapper/UserMapper.java
@@ -1,0 +1,10 @@
+package ru.practicum.explorewithme.main.mapper;
+
+import org.mapstruct.Mapper;
+import ru.practicum.explorewithme.main.dto.UserShortDto;
+import ru.practicum.explorewithme.main.models.User;
+
+@Mapper(componentModel = "spring")
+public interface UserMapper {
+    UserShortDto toShortDto(User user);
+}

--- a/main-service/src/main/java/ru/practicum/explorewithme/main/model/Category.java
+++ b/main-service/src/main/java/ru/practicum/explorewithme/main/model/Category.java
@@ -1,4 +1,4 @@
-package ru.practicum.explorewithme.main.models;
+package ru.practicum.explorewithme.main.model;
 
 import jakarta.persistence.*;
 import lombok.*;

--- a/main-service/src/main/java/ru/practicum/explorewithme/main/model/Compilation.java
+++ b/main-service/src/main/java/ru/practicum/explorewithme/main/model/Compilation.java
@@ -1,4 +1,4 @@
-package ru.practicum.explorewithme.main.models;
+package ru.practicum.explorewithme.main.model;
 
 import jakarta.persistence.*;
 import lombok.*;

--- a/main-service/src/main/java/ru/practicum/explorewithme/main/model/Event.java
+++ b/main-service/src/main/java/ru/practicum/explorewithme/main/model/Event.java
@@ -1,4 +1,4 @@
-package ru.practicum.explorewithme.main.models;
+package ru.practicum.explorewithme.main.model;
 
 import jakarta.persistence.*;
 import lombok.*;

--- a/main-service/src/main/java/ru/practicum/explorewithme/main/model/EventState.java
+++ b/main-service/src/main/java/ru/practicum/explorewithme/main/model/EventState.java
@@ -1,4 +1,4 @@
-package ru.practicum.explorewithme.main.models;
+package ru.practicum.explorewithme.main.model;
 
 /**
  * Состояния жизненного цикла события

--- a/main-service/src/main/java/ru/practicum/explorewithme/main/model/Location.java
+++ b/main-service/src/main/java/ru/practicum/explorewithme/main/model/Location.java
@@ -1,4 +1,4 @@
-package ru.practicum.explorewithme.main.models;
+package ru.practicum.explorewithme.main.model;
 
 import jakarta.persistence.*;
 import lombok.*;

--- a/main-service/src/main/java/ru/practicum/explorewithme/main/model/ParticipationRequest.java
+++ b/main-service/src/main/java/ru/practicum/explorewithme/main/model/ParticipationRequest.java
@@ -1,4 +1,4 @@
-package ru.practicum.explorewithme.main.models;
+package ru.practicum.explorewithme.main.model;
 
 import jakarta.persistence.*;
 import lombok.*;

--- a/main-service/src/main/java/ru/practicum/explorewithme/main/model/RequestStatus.java
+++ b/main-service/src/main/java/ru/practicum/explorewithme/main/model/RequestStatus.java
@@ -1,4 +1,4 @@
-package ru.practicum.explorewithme.main.models;
+package ru.practicum.explorewithme.main.model;
 
 /**
  * Статусы запросов на участие в событии

--- a/main-service/src/main/java/ru/practicum/explorewithme/main/model/User.java
+++ b/main-service/src/main/java/ru/practicum/explorewithme/main/model/User.java
@@ -1,4 +1,4 @@
-package ru.practicum.explorewithme.main.models;
+package ru.practicum.explorewithme.main.model;
 
 import jakarta.persistence.*;
 import lombok.*;

--- a/main-service/src/main/java/ru/practicum/explorewithme/main/repository/EventRepository.java
+++ b/main-service/src/main/java/ru/practicum/explorewithme/main/repository/EventRepository.java
@@ -2,7 +2,7 @@ package ru.practicum.explorewithme.main.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.querydsl.QuerydslPredicateExecutor;
-import ru.practicum.explorewithme.main.models.Event;
+import ru.practicum.explorewithme.main.model.Event;
 
 public interface EventRepository extends JpaRepository<Event, Long>, QuerydslPredicateExecutor<Event> {
 

--- a/main-service/src/main/java/ru/practicum/explorewithme/main/repository/EventRepository.java
+++ b/main-service/src/main/java/ru/practicum/explorewithme/main/repository/EventRepository.java
@@ -1,0 +1,9 @@
+package ru.practicum.explorewithme.main.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.querydsl.QuerydslPredicateExecutor;
+import ru.practicum.explorewithme.main.models.Event;
+
+public interface EventRepository extends JpaRepository<Event, Long>, QuerydslPredicateExecutor<Event> {
+
+}

--- a/main-service/src/main/java/ru/practicum/explorewithme/main/service/EventService.java
+++ b/main-service/src/main/java/ru/practicum/explorewithme/main/service/EventService.java
@@ -1,0 +1,18 @@
+package ru.practicum.explorewithme.main.service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import ru.practicum.explorewithme.main.dto.EventFullDto;
+import ru.practicum.explorewithme.main.models.EventState;
+
+public interface EventService {
+    List<EventFullDto> getEventsAdmin(
+        List<Long> users,
+        List<EventState> states,
+        List<Long> categories,
+        LocalDateTime rangeStart,
+        LocalDateTime rangeEnd,
+        int from,
+        int size
+    );
+}

--- a/main-service/src/main/java/ru/practicum/explorewithme/main/service/EventService.java
+++ b/main-service/src/main/java/ru/practicum/explorewithme/main/service/EventService.java
@@ -1,17 +1,12 @@
 package ru.practicum.explorewithme.main.service;
 
-import java.time.LocalDateTime;
 import java.util.List;
 import ru.practicum.explorewithme.main.dto.EventFullDto;
-import ru.practicum.explorewithme.main.models.EventState;
+import ru.practicum.explorewithme.main.service.params.AdminEventSearchParams;
 
 public interface EventService {
     List<EventFullDto> getEventsAdmin(
-        List<Long> users,
-        List<EventState> states,
-        List<Long> categories,
-        LocalDateTime rangeStart,
-        LocalDateTime rangeEnd,
+        AdminEventSearchParams params,
         int from,
         int size
     );

--- a/main-service/src/main/java/ru/practicum/explorewithme/main/service/EventServiceImpl.java
+++ b/main-service/src/main/java/ru/practicum/explorewithme/main/service/EventServiceImpl.java
@@ -73,7 +73,7 @@ public class EventServiceImpl implements EventService {
         if (rangeEnd != null) {
             predicate.and(qEvent.eventDate.loe(rangeEnd)); // lower or equal
         }
-        
+
         Predicate finalPredicate = predicate.getValue();
 
         Pageable pageable = PageRequest.of(from / size, size, Sort.by(Sort.Direction.ASC, "id"));

--- a/main-service/src/main/java/ru/practicum/explorewithme/main/service/EventServiceImpl.java
+++ b/main-service/src/main/java/ru/practicum/explorewithme/main/service/EventServiceImpl.java
@@ -21,6 +21,7 @@ import ru.practicum.explorewithme.main.repository.EventRepository;
 import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.List;
+import ru.practicum.explorewithme.main.service.params.AdminEventSearchParams;
 
 @Service
 @RequiredArgsConstructor
@@ -34,13 +35,15 @@ public class EventServiceImpl implements EventService {
     // private final CategoryRepository categoryRepository;
 
     @Override
-    public List<EventFullDto> getEventsAdmin(List<Long> users,
-        List<EventState> states,
-        List<Long> categories,
-        LocalDateTime rangeStart,
-        LocalDateTime rangeEnd,
+    public List<EventFullDto> getEventsAdmin(AdminEventSearchParams params,
         int from,
         int size) {
+
+        List<Long> users = params.getUsers();
+        List<EventState> states = params.getStates();
+        List<Long> categories = params.getCategories();
+        LocalDateTime rangeStart = params.getRangeStart();
+        LocalDateTime rangeEnd = params.getRangeEnd();
 
         log.debug("Admin search for events with params: users={}, states={}, categories={}, rangeStart={}, rangeEnd={}, from={}, size={}",
             users, states, categories, rangeStart, rangeEnd, from, size);

--- a/main-service/src/main/java/ru/practicum/explorewithme/main/service/EventServiceImpl.java
+++ b/main-service/src/main/java/ru/practicum/explorewithme/main/service/EventServiceImpl.java
@@ -12,9 +12,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import ru.practicum.explorewithme.main.dto.EventFullDto;
 import ru.practicum.explorewithme.main.mapper.EventMapper;
-import ru.practicum.explorewithme.main.models.Event;
-import ru.practicum.explorewithme.main.models.EventState;
-import ru.practicum.explorewithme.main.models.QEvent;
+import ru.practicum.explorewithme.main.model.Event;
+import ru.practicum.explorewithme.main.model.EventState;
+import ru.practicum.explorewithme.main.model.QEvent;
 import ru.practicum.explorewithme.main.repository.EventRepository;
 // import ru.practicum.explorewithme.main.exception.NotFoundException;
 

--- a/main-service/src/main/java/ru/practicum/explorewithme/main/service/EventServiceImpl.java
+++ b/main-service/src/main/java/ru/practicum/explorewithme/main/service/EventServiceImpl.java
@@ -78,7 +78,7 @@ public class EventServiceImpl implements EventService {
 
         Pageable pageable = PageRequest.of(from / size, size, Sort.by(Sort.Direction.ASC, "id"));
 
-        Page<Event> eventPage = eventRepository.findAll(finalPredicate, pageable);
+        Page<Event> eventPage = eventRepository.findAll(predicate, pageable);
 
         if (eventPage.isEmpty()) {
             return Collections.emptyList();

--- a/main-service/src/main/java/ru/practicum/explorewithme/main/service/EventServiceImpl.java
+++ b/main-service/src/main/java/ru/practicum/explorewithme/main/service/EventServiceImpl.java
@@ -1,0 +1,92 @@
+package ru.practicum.explorewithme.main.service;
+
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.Predicate;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import ru.practicum.explorewithme.main.dto.EventFullDto;
+import ru.practicum.explorewithme.main.mapper.EventMapper;
+import ru.practicum.explorewithme.main.models.Event;
+import ru.practicum.explorewithme.main.models.EventState;
+import ru.practicum.explorewithme.main.models.QEvent;
+import ru.practicum.explorewithme.main.repository.EventRepository;
+// import ru.practicum.explorewithme.main.exception.NotFoundException;
+
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Slf4j
+public class EventServiceImpl implements EventService {
+
+    private final EventRepository eventRepository;
+    private final EventMapper eventMapper;
+    // private final UserRepository userRepository;
+    // private final CategoryRepository categoryRepository;
+
+    @Override
+    public List<EventFullDto> getEventsAdmin(List<Long> users,
+        List<EventState> states,
+        List<Long> categories,
+        LocalDateTime rangeStart,
+        LocalDateTime rangeEnd,
+        int from,
+        int size) {
+
+        log.debug("Admin search for events with params: users={}, states={}, categories={}, rangeStart={}, rangeEnd={}, from={}, size={}",
+            users, states, categories, rangeStart, rangeEnd, from, size);
+
+        if (rangeStart != null && rangeEnd != null && rangeStart.isAfter(rangeEnd)) {
+            throw new IllegalArgumentException("Admin search: rangeStart cannot be after rangeEnd.");
+        }
+
+        QEvent qEvent = QEvent.event;
+        BooleanBuilder predicate = new BooleanBuilder();
+
+        if (users != null && !users.isEmpty()) {
+            // TODO: Возможно, стоит проверить, существуют ли такие пользователи, если это требуется по логике
+            predicate.and(qEvent.initiator.id.in(users));
+        }
+
+        if (states != null && !states.isEmpty()) {
+            predicate.and(qEvent.state.in(states));
+        }
+
+        if (categories != null && !categories.isEmpty()) {
+            // TODO: Возможно, стоит проверить, существуют ли такие категории
+            predicate.and(qEvent.category.id.in(categories));
+        }
+
+        if (rangeStart != null) {
+            predicate.and(qEvent.eventDate.goe(rangeStart)); // greater or equal
+        }
+
+        if (rangeEnd != null) {
+            predicate.and(qEvent.eventDate.loe(rangeEnd)); // lower or equal
+        }
+        
+        Predicate finalPredicate = predicate.getValue();
+
+        Pageable pageable = PageRequest.of(from / size, size, Sort.by(Sort.Direction.ASC, "id"));
+
+        Page<Event> eventPage = eventRepository.findAll(finalPredicate, pageable);
+
+        if (eventPage.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        List<EventFullDto> result = eventMapper.toEventFullDtoList(eventPage.getContent());
+        log.debug("Admin search found {} events on page {}/{}", result.size(), pageable.getPageNumber(), eventPage.getTotalPages());
+        return result;
+    }
+
+}

--- a/main-service/src/main/java/ru/practicum/explorewithme/main/service/params/AdminEventSearchParams.java
+++ b/main-service/src/main/java/ru/practicum/explorewithme/main/service/params/AdminEventSearchParams.java
@@ -1,0 +1,19 @@
+package ru.practicum.explorewithme.main.service.params;
+
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import ru.practicum.explorewithme.main.models.EventState;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Builder
+@EqualsAndHashCode(of = {"users", "states", "categories", "rangeStart", "rangeEnd"})
+public class AdminEventSearchParams {
+    private final List<Long> users;
+    private final List<EventState> states;
+    private final List<Long> categories;
+    private final LocalDateTime rangeStart;
+    private final LocalDateTime rangeEnd;
+}

--- a/main-service/src/main/java/ru/practicum/explorewithme/main/service/params/AdminEventSearchParams.java
+++ b/main-service/src/main/java/ru/practicum/explorewithme/main/service/params/AdminEventSearchParams.java
@@ -3,7 +3,7 @@ package ru.practicum.explorewithme.main.service.params;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
-import ru.practicum.explorewithme.main.models.EventState;
+import ru.practicum.explorewithme.main.model.EventState;
 import java.time.LocalDateTime;
 import java.util.List;
 

--- a/main-service/src/test/java/ru/practicum/explorewithme/main/controller/admin/AdminEventControllerTest.java
+++ b/main-service/src/test/java/ru/practicum/explorewithme/main/controller/admin/AdminEventControllerTest.java
@@ -27,7 +27,7 @@ import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import ru.practicum.explorewithme.main.dto.EventFullDto;
-import ru.practicum.explorewithme.main.models.EventState;
+import ru.practicum.explorewithme.main.model.EventState;
 import ru.practicum.explorewithme.main.service.EventService;
 import ru.practicum.explorewithme.main.service.params.AdminEventSearchParams;
 

--- a/main-service/src/test/java/ru/practicum/explorewithme/main/controller/admin/AdminEventControllerTest.java
+++ b/main-service/src/test/java/ru/practicum/explorewithme/main/controller/admin/AdminEventControllerTest.java
@@ -1,0 +1,154 @@
+package ru.practicum.explorewithme.main.controller.admin; // Убедитесь, что пакет совпадает
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static ru.practicum.explorewithme.common.constants.DateTimeConstants.DATE_TIME_FORMATTER;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import ru.practicum.explorewithme.main.dto.EventFullDto;
+import ru.practicum.explorewithme.main.models.EventState;
+import ru.practicum.explorewithme.main.service.EventService;
+
+@WebMvcTest(AdminEventController.class)
+@DisplayName("Тесты для AdminEventController")
+class AdminEventControllerTest {
+
+    private final DateTimeFormatter formatter = DATE_TIME_FORMATTER;
+    @Autowired
+    private MockMvc mockMvc;
+    @Autowired
+    private ObjectMapper objectMapper;
+    @MockitoBean
+    private EventService eventService;
+
+    @Test
+    @DisplayName("Поиск событий администратором: должен вернуть 200 OK и пустой список, если "
+        + "событий не найдено")
+    void searchEventsAdmin_whenNoEventsFound_shouldReturnOkAndEmptyList() throws Exception {
+        // Arrange
+        when(eventService.getEventsAdmin(any(), any(), any(), any(), any(), anyInt(),
+            anyInt())).thenReturn(Collections.emptyList());
+
+        // Act & Assert
+        mockMvc.perform(get("/admin/events").param("from", "0").param("size", "10")
+                .contentType(MediaType.APPLICATION_JSON).characterEncoding(StandardCharsets.UTF_8))
+            .andExpect(status().isOk()).andExpect(jsonPath("$", hasSize(0)));
+
+        verify(eventService).getEventsAdmin(null, null, null, null, null, 0, 10);
+    }
+
+    @Test
+    @DisplayName("Поиск событий администратором: должен вернуть 200 OK и список событий, если они"
+        + " найдены")
+    void searchEventsAdmin_whenEventsFound_shouldReturnOkAndEventList() throws Exception {
+        LocalDateTime eventTime = LocalDateTime.now().plusDays(5).withNano(0);
+        EventFullDto eventDto = EventFullDto.builder().id(1L).title("Test Event")
+            .annotation("Test Annotation").eventDate(eventTime).build();
+        List<EventFullDto> events = List.of(eventDto);
+
+        when(eventService.getEventsAdmin(any(), any(), any(), any(), any(), eq(0),
+            eq(10))).thenReturn(events);
+
+        mockMvc.perform(get("/admin/events").param("from", "0").param("size", "10")
+                .contentType(MediaType.APPLICATION_JSON)).andExpect(status().isOk())
+            .andExpect(jsonPath("$", hasSize(1)))
+            .andExpect(jsonPath("$[0].id", is(eventDto.getId().intValue())))
+            .andExpect(jsonPath("$[0].title", is(eventDto.getTitle()))).andExpect(
+                jsonPath("$[0].eventDate", is(eventTime.format(formatter)))); // Проверка формата
+        // даты
+
+        verify(eventService).getEventsAdmin(null, null, null, null, null, 0, 10);
+    }
+
+    @Test
+    @DisplayName("Поиск событий администратором: должен корректно передавать все параметры "
+        + "фильтрации в сервис")
+    void searchEventsAdmin_withAllFilters_shouldPassFiltersToService() throws Exception {
+        List<Long> userIds = List.of(1L, 2L);
+        List<EventState> states = List.of(EventState.PENDING, EventState.PUBLISHED);
+        List<Long> categoryIds = List.of(10L, 20L);
+        LocalDateTime rangeStart = LocalDateTime.now().minusDays(1).withNano(0);
+        LocalDateTime rangeEnd = LocalDateTime.now().plusDays(1).withNano(0);
+        int from = 5;
+        int size = 15;
+
+        when(eventService.getEventsAdmin(eq(userIds), eq(states), eq(categoryIds), eq(rangeStart),
+            eq(rangeEnd), eq(from), eq(size))).thenReturn(Collections.emptyList());
+
+        mockMvc.perform(
+                get("/admin/events").param("users", "1", "2").param("states", "PENDING",
+                        "PUBLISHED")
+                    .param("categories", "10", "20").param("rangeStart",
+                        rangeStart.format(formatter))
+                    .param("rangeEnd", rangeEnd.format(formatter)).param("from",
+                        String.valueOf(from))
+                    .param("size", String.valueOf(size)).contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk()).andExpect(jsonPath("$", hasSize(0)));
+
+        verify(eventService).getEventsAdmin(userIds, states, categoryIds, rangeStart, rangeEnd,
+            from, size);
+    }
+
+    @Test
+    @DisplayName("Поиск событий администратором: должен использовать значения по умолчанию для "
+        + "from и size, если они не переданы")
+    void searchEventsAdmin_withDefaultPagination_shouldUseDefaultValues() throws Exception {
+        when(eventService.getEventsAdmin(any(), any(), any(), any(), any(), eq(0),
+            eq(10))).thenReturn(Collections.emptyList());
+
+        mockMvc.perform(get("/admin/events").contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk());
+
+        verify(eventService).getEventsAdmin(null, null, null, null, null, 0, 10);
+    }
+
+    @Test
+    @DisplayName("Поиск событий администратором: должен вернуть 400 Bad Request при невалидном "
+        + "значении 'from'")
+    void searchEventsAdmin_withInvalidFrom_shouldReturnBadRequest() throws Exception {
+        mockMvc.perform(get("/admin/events").param("from", "-1") // Невалидное значение
+                .param("size", "10").contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isBadRequest());
+        verifyNoInteractions(eventService); // Сервис не должен вызываться
+    }
+
+    @Test
+    @DisplayName("Поиск событий администратором: должен вернуть 400 Bad Request при невалидном "
+        + "значении 'size'")
+    void searchEventsAdmin_withInvalidSize_shouldReturnBadRequest() throws Exception {
+        mockMvc.perform(get("/admin/events").param("from", "0")
+            .param("size", "0") // Невалидное значение (@Positive)
+            .contentType(MediaType.APPLICATION_JSON)).andExpect(status().isBadRequest());
+        verifyNoInteractions(eventService);
+    }
+
+    @Test
+    @DisplayName("Поиск событий администратором: должен вернуть 400 Bad Request при некорректном "
+        + "формате rangeStart")
+    void searchEventsAdmin_withInvalidRangeStartFormat_shouldReturnBadRequest() throws Exception {
+        mockMvc.perform(get("/admin/events").param("rangeStart", "invalid-date-format")
+            .param("rangeEnd", LocalDateTime.now().format(formatter)).param("from", "0")
+            .param("size", "10")).andExpect(status().isBadRequest());
+    }
+}

--- a/main-service/src/test/java/ru/practicum/explorewithme/main/mapper/EventMapperTest.java
+++ b/main-service/src/test/java/ru/practicum/explorewithme/main/mapper/EventMapperTest.java
@@ -1,0 +1,206 @@
+package ru.practicum.explorewithme.main.mapper;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import ru.practicum.explorewithme.main.dto.CategoryDto;
+import ru.practicum.explorewithme.main.dto.EventFullDto;
+import ru.practicum.explorewithme.main.dto.UserShortDto;
+import ru.practicum.explorewithme.main.models.Category;
+import ru.practicum.explorewithme.main.models.Event;
+import ru.practicum.explorewithme.main.models.EventState;
+import ru.practicum.explorewithme.main.models.Location;
+import ru.practicum.explorewithme.main.models.User;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("Тесты для EventMapper")
+class EventMapperTest {
+
+    @Mock
+    private CategoryMapper categoryMapper;
+
+    @Mock
+    private UserMapper userMapper;
+
+    @InjectMocks
+    private EventMapperImpl eventMapper;
+
+    @Nested
+    @DisplayName("Метод toEventFullDto (маппинг одиночного события в EventFullDto)")
+    class ToEventFullDtoTests {
+
+        @Test
+        @DisplayName("Должен корректно маппить все поля, когда все данные присутствуют")
+        void toEventFullDto_shouldMapAllFieldsCorrectly() {
+            User initiatorModel = User.builder().id(1L).name("Test User").email("user@test.com").build();
+            Category categoryModel = Category.builder().id(10L).name("Test Category").build();
+            Location locationModel = Location.builder().lat(55.75f).lon(37.62f).build();
+
+            Event event = Event.builder()
+                .id(1L)
+                .annotation("Test Annotation")
+                .category(categoryModel)
+                .createdOn(LocalDateTime.now().minusDays(1))
+                .description("Test Description")
+                .eventDate(LocalDateTime.now().plusDays(5))
+                .initiator(initiatorModel)
+                .location(locationModel)
+                .paid(true)
+                .participantLimit(100)
+                .publishedOn(LocalDateTime.now())
+                .requestModeration(true)
+                .state(EventState.PUBLISHED)
+                .title("Test Event Title")
+                .build();
+
+            CategoryDto categoryDto = CategoryDto.builder().id(categoryModel.getId()).name(categoryModel.getName()).build();
+            when(categoryMapper.toDto(any(Category.class))).thenReturn(categoryDto);
+
+            UserShortDto userShortDto = UserShortDto.builder().id(initiatorModel.getId()).name(initiatorModel.getName()).build();
+            when(userMapper.toShortDto(any(User.class))).thenReturn(userShortDto);
+
+            EventFullDto dto = eventMapper.toEventFullDto(event);
+
+            assertNotNull(dto);
+            assertEquals(event.getId(), dto.getId());
+            assertEquals(event.getAnnotation(), dto.getAnnotation());
+            assertEquals(event.getCreatedOn(), dto.getCreatedOn());
+            assertEquals(event.getDescription(), dto.getDescription());
+            assertEquals(event.getEventDate(), dto.getEventDate());
+            assertEquals(event.isPaid(), dto.isPaid());
+            assertEquals(event.getParticipantLimit(), dto.getParticipantLimit());
+            assertEquals(event.getPublishedOn(), dto.getPublishedOn());
+            assertEquals(event.isRequestModeration(), dto.isRequestModeration());
+            assertEquals(event.getState(), dto.getState());
+            assertEquals(event.getTitle(), dto.getTitle());
+
+
+            assertNotNull(dto.getCategory());
+            assertEquals(categoryModel.getId(), dto.getCategory().getId());
+            assertEquals(categoryModel.getName(), dto.getCategory().getName());
+
+            assertNotNull(dto.getInitiator());
+            assertEquals(initiatorModel.getId(), dto.getInitiator().getId());
+            assertEquals(initiatorModel.getName(), dto.getInitiator().getName());
+
+            assertNotNull(dto.getLocation());
+            assertEquals(locationModel.getLat(), dto.getLocation().getLat());
+            assertEquals(locationModel.getLon(), dto.getLocation().getLon());
+
+            assertEquals(0L, dto.getConfirmedRequests());
+            assertEquals(0L, dto.getViews());
+        }
+
+        @Test
+        @DisplayName("Должен возвращать null, если на вход подан null Event")
+        void toEventFullDto_shouldHandleNullEvent() {
+            EventFullDto dto = eventMapper.toEventFullDto(null);
+            assertNull(dto);
+        }
+
+        @Test
+        @DisplayName("Должен корректно обрабатывать null для вложенных объектов (категория, инициатор, локация)")
+        void toEventFullDto_shouldHandleNullNestedObjects() {
+            Event event = Event.builder()
+                .id(1L)
+                .annotation("Test Annotation")
+                // category, initiator, location остаются null
+                .createdOn(LocalDateTime.now().minusDays(1))
+                .description("Test Description")
+                .eventDate(LocalDateTime.now().plusDays(5))
+                .paid(true)
+                .participantLimit(100)
+                .publishedOn(LocalDateTime.now())
+                .requestModeration(true)
+                .state(EventState.PUBLISHED)
+                .title("Test Event Title")
+                .build();
+
+            when(categoryMapper.toDto(null)).thenReturn(null);
+            when(userMapper.toShortDto(null)).thenReturn(null);
+
+            EventFullDto dto = eventMapper.toEventFullDto(event);
+
+            assertNotNull(dto);
+            assertNull(dto.getCategory());
+            assertNull(dto.getInitiator());
+            assertNull(dto.getLocation());
+        }
+    }
+
+
+    @Nested
+    @DisplayName("Метод toEventFullDtoList (маппинг списка событий в список EventFullDto)")
+    class ToEventFullDtoListTests {
+
+        @Test
+        @DisplayName("должен корректно маппить список событий")
+        void toEventFullDtoList_shouldMapListOfEvents() {
+            User initiatorModel = User.builder().id(1L).name("Test User").build();
+            Category categoryModel = Category.builder().id(10L).name("Test Category").build();
+            Location locationModel = Location.builder().lat(55.75f).lon(37.62f).build();
+
+            Event event1 = Event.builder().id(1L).title("Event 1").category(categoryModel).initiator(initiatorModel).location(locationModel).eventDate(LocalDateTime.now()).createdOn(LocalDateTime.now()).annotation("A1").description("D1").state(EventState.PENDING).paid(false).participantLimit(10).requestModeration(false).publishedOn(null).build();
+            Event event2 = Event.builder().id(2L).title("Event 2").category(categoryModel).initiator(initiatorModel).location(locationModel).eventDate(LocalDateTime.now()).createdOn(LocalDateTime.now()).annotation("A2").description("D2").state(EventState.PUBLISHED).paid(true).participantLimit(20).requestModeration(true).publishedOn(LocalDateTime.now()).build();
+            List<Event> events = Arrays.asList(event1, event2);
+
+            CategoryDto categoryDto = CategoryDto.builder().id(categoryModel.getId()).name(categoryModel.getName()).build();
+            UserShortDto userShortDto = UserShortDto.builder().id(initiatorModel.getId()).name(initiatorModel.getName()).build();
+
+            // Настраиваем моки для зависимых мапперов.
+            when(categoryMapper.toDto(categoryModel)).thenReturn(categoryDto);
+            when(userMapper.toShortDto(initiatorModel)).thenReturn(userShortDto);
+
+            List<EventFullDto> dtoList = eventMapper.toEventFullDtoList(events);
+
+            assertNotNull(dtoList);
+            assertEquals(2, dtoList.size());
+
+            // Проверки для первого элемента списка
+            EventFullDto dto1 = dtoList.get(0);
+            assertEquals(event1.getTitle(), dto1.getTitle());
+            assertNotNull(dto1.getCategory());
+            assertEquals(categoryModel.getName(), dto1.getCategory().getName());
+            assertNotNull(dto1.getInitiator());
+            assertEquals(initiatorModel.getName(), dto1.getInitiator().getName());
+
+            // Проверки для второго элемента списка
+            EventFullDto dto2 = dtoList.get(1);
+            assertEquals(event2.getTitle(), dto2.getTitle());
+            assertNotNull(dto2.getCategory());
+            assertEquals(categoryModel.getName(), dto2.getCategory().getName());
+            assertNotNull(dto2.getInitiator());
+            assertEquals(initiatorModel.getName(), dto2.getInitiator().getName());
+        }
+
+        @Test
+        @DisplayName("должен возвращать null, если на вход подан null список")
+        void toEventFullDtoList_shouldHandleNullList() {
+            List<EventFullDto> dtoList = eventMapper.toEventFullDtoList(null);
+            assertNull(dtoList);
+        }
+
+        @Test
+        @DisplayName("должен возвращать пустой список, если на вход подан пустой список")
+        void toEventFullDtoList_shouldHandleEmptyList() {
+            List<EventFullDto> dtoList = eventMapper.toEventFullDtoList(Collections.emptyList());
+            assertNotNull(dtoList);
+            assertTrue(dtoList.isEmpty());
+        }
+    }
+}

--- a/main-service/src/test/java/ru/practicum/explorewithme/main/mapper/EventMapperTest.java
+++ b/main-service/src/test/java/ru/practicum/explorewithme/main/mapper/EventMapperTest.java
@@ -21,11 +21,11 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import ru.practicum.explorewithme.main.dto.CategoryDto;
 import ru.practicum.explorewithme.main.dto.EventFullDto;
 import ru.practicum.explorewithme.main.dto.UserShortDto;
-import ru.practicum.explorewithme.main.models.Category;
-import ru.practicum.explorewithme.main.models.Event;
-import ru.practicum.explorewithme.main.models.EventState;
-import ru.practicum.explorewithme.main.models.Location;
-import ru.practicum.explorewithme.main.models.User;
+import ru.practicum.explorewithme.main.model.Category;
+import ru.practicum.explorewithme.main.model.Event;
+import ru.practicum.explorewithme.main.model.EventState;
+import ru.practicum.explorewithme.main.model.Location;
+import ru.practicum.explorewithme.main.model.User;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("Тесты для EventMapper")

--- a/main-service/src/test/java/ru/practicum/explorewithme/main/repository/EventRepositoryTest.java
+++ b/main-service/src/test/java/ru/practicum/explorewithme/main/repository/EventRepositoryTest.java
@@ -1,0 +1,253 @@
+package ru.practicum.explorewithme.main.repository;
+
+import com.querydsl.core.BooleanBuilder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+import ru.practicum.explorewithme.main.models.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DataJpaTest
+@Testcontainers
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@DisplayName("Интеграционные тесты для EventRepository с QueryDSL")
+class EventRepositoryTest {
+
+    @Container
+    private static final PostgreSQLContainer<?> postgresqlContainer = new PostgreSQLContainer<>(
+        DockerImageName.parse("postgres:16.1"));
+
+    @DynamicPropertySource
+    static void postgresqlProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", postgresqlContainer::getJdbcUrl);
+        registry.add("spring.datasource.username", postgresqlContainer::getUsername);
+        registry.add("spring.datasource.password", postgresqlContainer::getPassword);
+        registry.add("spring.jpa.hibernate.ddl-auto", () -> "create-drop");
+    }
+
+    @Autowired
+    private TestEntityManager entityManager;
+
+    @Autowired
+    private EventRepository eventRepository;
+
+    private User user1, user2;
+    private Category category1, category2;
+    private Location location1, location2;
+    private Event event1, event2, event3, event4;
+    private LocalDateTime now;
+
+    @BeforeEach
+    void setUp() {
+        now = LocalDateTime.now().withNano(0);
+
+        // Создаем и сохраняем пользователей
+        user1 = User.builder().name("User One").email("user1@test.com").build();
+        user2 = User.builder().name("User Two").email("user2@test.com").build();
+        entityManager.persist(user1);
+        entityManager.persist(user2);
+
+        // Создаем и сохраняем категории
+        category1 = Category.builder().name("Category One").build();
+        category2 = Category.builder().name("Category Two").build();
+        entityManager.persist(category1);
+        entityManager.persist(category2);
+
+        // Создаем локации (они @Embeddable, не сохраняются отдельно)
+        location1 = Location.builder().lat(10.0f).lon(20.0f).build();
+        location2 = Location.builder().lat(30.0f).lon(40.0f).build();
+
+        // Создаем и сохраняем события
+        event1 = Event.builder()
+            .title("Event Alpha")
+            .annotation("Annotation for Alpha")
+            .description("Description for Alpha")
+            .category(category1)
+            .initiator(user1)
+            .location(location1)
+            .eventDate(now.plusDays(5))
+            .createdOn(now.minusDays(1))
+            .state(EventState.PENDING)
+            .paid(false)
+            .participantLimit(10)
+            .requestModeration(true)
+            .build();
+
+        event2 = Event.builder()
+            .title("Event Beta")
+            .annotation("Annotation for Beta")
+            .description("Description for Beta")
+            .category(category2)
+            .initiator(user1) // тот же user1
+            .location(location2)
+            .eventDate(now.plusDays(10))
+            .createdOn(now.minusDays(2))
+            .state(EventState.PUBLISHED)
+            .paid(true)
+            .participantLimit(0) // без лимита
+            .requestModeration(false)
+            .build();
+
+        event3 = Event.builder()
+            .title("Event Gamma")
+            .annotation("Annotation for Gamma")
+            .description("Description for Gamma")
+            .category(category1)
+            .initiator(user2)
+            .location(location1)
+            .eventDate(now.plusDays(15))
+            .createdOn(now.minusDays(3))
+            .state(EventState.PUBLISHED)
+            .paid(false)
+            .participantLimit(5)
+            .requestModeration(true)
+            .build();
+
+        event4 = Event.builder()
+            .title("Event Delta Past Published")
+            .annotation("Annotation for Delta")
+            .description("Description for Delta")
+            .category(category2)
+            .initiator(user2)
+            .location(location2)
+            .eventDate(now.minusDays(1))
+            .publishedOn(now.minusDays(2))
+            .createdOn(now.minusDays(3))
+            .state(EventState.PUBLISHED)
+            .paid(true)
+            .participantLimit(20)
+            .requestModeration(true)
+            .build();
+
+        eventRepository.saveAll(List.of(event1, event2, event3, event4));
+        entityManager.flush();
+        entityManager.clear();
+    }
+
+    @Test
+    @DisplayName("Поиск без фильтров должен вернуть все события с пагинацией")
+    void findAll_withNoFilters_shouldReturnAllEventsPaged() {
+        Pageable pageable = PageRequest.of(0, 2);
+        BooleanBuilder predicate = new BooleanBuilder();
+
+        Page<Event> result = eventRepository.findAll(predicate, pageable);
+
+        assertEquals(2, result.getContent().size());
+        assertEquals(4, result.getTotalElements());
+        assertTrue(result.getContent().stream().anyMatch(e -> e.getTitle().equals("Event Alpha")));
+    }
+
+    @Test
+    @DisplayName("Фильтрация по ID пользователей (users)")
+    void findAll_withUserFilter_shouldReturnUserEvents() {
+        QEvent qEvent = QEvent.event;
+        BooleanBuilder predicate = new BooleanBuilder();
+        predicate.and(qEvent.initiator.id.in(List.of(user1.getId())));
+
+        assertNotNull(predicate.getValue());
+        Page<Event> result = eventRepository.findAll(predicate.getValue(), PageRequest.of(0, 10));
+
+        assertEquals(2, result.getTotalElements());
+        assertTrue(result.getContent().stream().allMatch(e -> e.getInitiator().getId().equals(user1.getId())));
+        assertTrue(result.getContent().stream().anyMatch(e -> e.getTitle().equals("Event Alpha")));
+        assertTrue(result.getContent().stream().anyMatch(e -> e.getTitle().equals("Event Beta")));
+    }
+
+    @Test
+    @DisplayName("Фильтрация по состояниям (states)")
+    void findAll_withStateFilter_shouldReturnMatchingStateEvents() {
+        QEvent qEvent = QEvent.event;
+        BooleanBuilder predicate = new BooleanBuilder();
+        predicate.and(qEvent.state.in(List.of(EventState.PUBLISHED)));
+
+        assertNotNull(predicate.getValue());
+        Page<Event> result = eventRepository.findAll(predicate.getValue(), PageRequest.of(0, 10));
+
+        assertEquals(3, result.getTotalElements()); // event2, event3, event4
+        assertTrue(result.getContent().stream().allMatch(e -> e.getState() == EventState.PUBLISHED));
+    }
+
+    @Test
+    @DisplayName("Фильтрация по ID категорий (categories)")
+    void findAll_withCategoryFilter_shouldReturnMatchingCategoryEvents() {
+        QEvent qEvent = QEvent.event;
+        BooleanBuilder predicate = new BooleanBuilder();
+        predicate.and(qEvent.category.id.in(List.of(category1.getId())));
+
+        assertNotNull(predicate.getValue());
+        Page<Event> result = eventRepository.findAll(predicate.getValue(), PageRequest.of(0, 10));
+
+        assertEquals(2, result.getTotalElements()); // event1, event3
+        assertTrue(result.getContent().stream().allMatch(e -> e.getCategory().getId().equals(category1.getId())));
+    }
+
+    @Test
+    @DisplayName("Фильтрация по начальной дате диапазона (rangeStart)")
+    void findAll_withRangeStartFilter_shouldReturnEventsAfterOrOnDate() {
+        QEvent qEvent = QEvent.event;
+        BooleanBuilder predicate = new BooleanBuilder();
+        LocalDateTime rangeStart = now.plusDays(12); // Только event3 должен попасть
+        predicate.and(qEvent.eventDate.goe(rangeStart));
+
+        assertNotNull(predicate.getValue());
+        Page<Event> result = eventRepository.findAll(predicate.getValue(), PageRequest.of(0, 10));
+
+        assertEquals(1, result.getTotalElements());
+        assertEquals("Event Gamma", result.getContent().getFirst().getTitle());
+    }
+
+    @Test
+    @DisplayName("Фильтрация по конечной дате диапазона (rangeEnd)")
+    void findAll_withRangeEndFilter_shouldReturnEventsBeforeOrOnDate() {
+        QEvent qEvent = QEvent.event;
+        BooleanBuilder predicate = new BooleanBuilder();
+        LocalDateTime rangeEnd = now.plusDays(7); // event1 и event4 (если бы не был в прошлом для другого теста)
+        // но event4 уже в прошлом, так что только event1
+        predicate.and(qEvent.eventDate.loe(rangeEnd));
+
+        assertNotNull(predicate.getValue());
+        Page<Event> result = eventRepository.findAll(predicate.getValue(), PageRequest.of(0, 10));
+
+        // event1 (now + 5 days)
+        // event4 (now - 1 day)
+        assertEquals(2, result.getTotalElements());
+        assertTrue(result.getContent().stream().anyMatch(e -> e.getTitle().equals("Event Alpha")));
+        assertTrue(result.getContent().stream().anyMatch(e -> e.getTitle().equals("Event Delta Past Published")));
+    }
+
+    @Test
+    @DisplayName("Комплексная фильтрация (user, state, category, range)")
+    void findAll_withMultipleFilters_shouldReturnCorrectEvents() {
+        QEvent qEvent = QEvent.event;
+        BooleanBuilder predicate = new BooleanBuilder();
+
+        // Ищем события user2, в состоянии PUBLISHED, в category1, в диапазоне дат
+        predicate.and(qEvent.initiator.id.eq(user2.getId()));
+        predicate.and(qEvent.state.eq(EventState.PUBLISHED));
+        predicate.and(qEvent.category.id.eq(category1.getId()));
+        predicate.and(qEvent.eventDate.between(now.plusDays(14), now.plusDays(16))); // event3
+
+        assertNotNull(predicate.getValue());
+        Page<Event> result = eventRepository.findAll(predicate.getValue(), PageRequest.of(0, 10));
+
+        assertEquals(1, result.getTotalElements());
+        assertEquals("Event Gamma", result.getContent().getFirst().getTitle());
+    }
+}

--- a/main-service/src/test/java/ru/practicum/explorewithme/main/repository/EventRepositoryTest.java
+++ b/main-service/src/test/java/ru/practicum/explorewithme/main/repository/EventRepositoryTest.java
@@ -17,7 +17,7 @@ import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.utility.DockerImageName;
-import ru.practicum.explorewithme.main.models.*;
+import ru.practicum.explorewithme.main.model.*;
 
 import java.time.LocalDateTime;
 import java.util.List;

--- a/main-service/src/test/java/ru/practicum/explorewithme/main/service/EventServiceImplTest.java
+++ b/main-service/src/test/java/ru/practicum/explorewithme/main/service/EventServiceImplTest.java
@@ -243,9 +243,9 @@ class EventServiceImplTest {
             int from = 0;
             int size = 10;
 
-            IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
-                eventService.getEventsAdmin(users, states, categories, rangeStart, rangeEnd, from, size);
-            });
+            IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+                () -> eventService.getEventsAdmin(users, states, categories, rangeStart, rangeEnd,
+                    from, size));
 
             assertEquals("Admin search: rangeStart cannot be after rangeEnd.", exception.getMessage());
 

--- a/main-service/src/test/java/ru/practicum/explorewithme/main/service/EventServiceImplTest.java
+++ b/main-service/src/test/java/ru/practicum/explorewithme/main/service/EventServiceImplTest.java
@@ -31,9 +31,9 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import ru.practicum.explorewithme.main.mapper.EventMapper;
-import ru.practicum.explorewithme.main.models.Event;
-import ru.practicum.explorewithme.main.models.EventState;
-import ru.practicum.explorewithme.main.models.QEvent;
+import ru.practicum.explorewithme.main.model.Event;
+import ru.practicum.explorewithme.main.model.EventState;
+import ru.practicum.explorewithme.main.model.QEvent;
 import ru.practicum.explorewithme.main.repository.EventRepository;
 import ru.practicum.explorewithme.main.service.params.AdminEventSearchParams;
 

--- a/main-service/src/test/java/ru/practicum/explorewithme/main/service/EventServiceImplTest.java
+++ b/main-service/src/test/java/ru/practicum/explorewithme/main/service/EventServiceImplTest.java
@@ -1,0 +1,230 @@
+package ru.practicum.explorewithme.main.service;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.isNull;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.querydsl.core.types.Predicate;
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import ru.practicum.explorewithme.main.mapper.EventMapper;
+import ru.practicum.explorewithme.main.models.Event;
+import ru.practicum.explorewithme.main.models.EventState;
+import ru.practicum.explorewithme.main.models.QEvent;
+import ru.practicum.explorewithme.main.repository.EventRepository;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("Тесты для реализации EventService")
+class EventServiceImplTest {
+
+    @Mock
+    private EventRepository eventRepository;
+
+    @Mock
+    private EventMapper eventMapper;
+
+    @InjectMocks
+    private EventServiceImpl eventService;
+
+    @Captor
+    private ArgumentCaptor<Predicate> predicateCaptor;
+
+    private LocalDateTime now;
+    private LocalDateTime plusOneHour;
+    private LocalDateTime plusTwoHours;
+    private QEvent qEvent;
+
+    @BeforeEach
+    void setUp() {
+        now = LocalDateTime.now();
+        plusOneHour = now.plusHours(1);
+        plusTwoHours = now.plusHours(2);
+        qEvent = QEvent.event;
+    }
+
+    @Nested
+    @DisplayName("Метод getEventsAdmin")
+    class GetEventsAdminTests {
+
+        @Test
+        @DisplayName("Должен формировать предикат, если передан фильтр по пользователям")
+        void getEventsAdmin_withUserFilter_shouldApplyUserPredicate() {
+            List<Long> users = List.of(1L, 2L);
+            Pageable pageable = PageRequest.of(0, 10, Sort.by(Sort.Direction.ASC, "id"));
+            Page<Event> emptyPage = new PageImpl<>(Collections.emptyList(), pageable, 0);
+
+            when(eventRepository.findAll(predicateCaptor.capture(), eq(pageable))).thenReturn(
+                emptyPage);
+
+            eventService.getEventsAdmin(users, null, null, null, null, 0, 10);
+
+            Predicate capturedPredicate = predicateCaptor.getValue();
+            assertNotNull(capturedPredicate, "Предикат не должен быть null, если есть фильтры");
+
+            String predicateString = capturedPredicate.toString();
+            assertTrue(predicateString.contains(qEvent.initiator.id.toString())
+                    && predicateString.contains("in [1, 2]"),
+                "Предикат должен содержать фильтр по ID пользователей");
+            verify(eventRepository).findAll(capturedPredicate, pageable);
+        }
+
+        @Test
+        @DisplayName("Должен формировать предикат, если передан фильтр по состояниям")
+        void getEventsAdmin_withStateFilter_shouldApplyStatePredicate() {
+            List<EventState> states = List.of(EventState.PENDING, EventState.PUBLISHED);
+            Pageable pageable = PageRequest.of(0, 10, Sort.by(Sort.Direction.ASC, "id"));
+            Page<Event> emptyPage = new PageImpl<>(Collections.emptyList(), pageable, 0);
+            when(eventRepository.findAll(predicateCaptor.capture(), eq(pageable))).thenReturn(
+                emptyPage);
+
+            eventService.getEventsAdmin(null, states, null, null, null, 0, 10);
+
+            Predicate capturedPredicate = predicateCaptor.getValue();
+            assertNotNull(capturedPredicate);
+            String predicateString = capturedPredicate.toString();
+            assertTrue(
+                predicateString.contains(qEvent.state.toString()) && predicateString.contains(
+                    "in [" + EventState.PENDING + ", " + EventState.PUBLISHED + "]"),
+                "Предикат должен содержать фильтр по состояниям");
+            verify(eventRepository).findAll(capturedPredicate, pageable);
+        }
+
+        @Test
+        @DisplayName("Должен формировать предикат, если передан фильтр по категориям")
+        void getEventsAdmin_withCategoryFilter_shouldApplyCategoryPredicate() {
+            List<Long> categories = List.of(5L);
+            Pageable pageable = PageRequest.of(0, 10, Sort.by(Sort.Direction.ASC, "id"));
+            Page<Event> emptyPage = new PageImpl<>(Collections.emptyList(), pageable, 0);
+            when(eventRepository.findAll(predicateCaptor.capture(), eq(pageable))).thenReturn(
+                emptyPage);
+
+            eventService.getEventsAdmin(null, null, categories, null, null, 0, 10);
+
+            Predicate capturedPredicate = predicateCaptor.getValue();
+            assertNotNull(capturedPredicate);
+            String predicateString = capturedPredicate.toString();
+
+            String categoryIdPath = qEvent.category.id.toString();
+
+            assertTrue(predicateString.contains(categoryIdPath + " = " + categories.getFirst()),
+                "Предикат должен содержать фильтр по ID категорий");
+            verify(eventRepository).findAll(capturedPredicate, pageable);
+        }
+
+
+        @Test
+        @DisplayName("Должен формировать предикат, если передана начальная дата диапазона")
+        void getEventsAdmin_withRangeStart_shouldApplyRangeStartPredicate() {
+            Pageable pageable = PageRequest.of(0, 10, Sort.by(Sort.Direction.ASC, "id"));
+            Page<Event> emptyPage = new PageImpl<>(Collections.emptyList(), pageable, 0);
+            when(eventRepository.findAll(predicateCaptor.capture(), eq(pageable))).thenReturn(
+                emptyPage);
+
+            eventService.getEventsAdmin(null, null, null, now, null, 0, 10);
+
+            Predicate capturedPredicate = predicateCaptor.getValue();
+            assertNotNull(capturedPredicate);
+            String predicateString = capturedPredicate.toString();
+            assertTrue(
+                predicateString.contains(qEvent.eventDate.toString()) && predicateString.contains(
+                    now.toString()), // goe(now)
+                "Предикат должен содержать фильтр по начальной дате");
+            verify(eventRepository).findAll(capturedPredicate, pageable);
+        }
+
+        @Test
+        @DisplayName("Должен формировать предикат, если передана конечная дата диапазона")
+        void getEventsAdmin_withRangeEnd_shouldApplyRangeEndPredicate() {
+            Pageable pageable = PageRequest.of(0, 10, Sort.by(Sort.Direction.ASC, "id"));
+            Page<Event> emptyPage = new PageImpl<>(Collections.emptyList(), pageable, 0);
+            when(eventRepository.findAll(predicateCaptor.capture(), eq(pageable))).thenReturn(
+                emptyPage);
+
+            eventService.getEventsAdmin(null, null, null, null, plusTwoHours, 0, 10);
+
+            Predicate capturedPredicate = predicateCaptor.getValue();
+            assertNotNull(capturedPredicate);
+            String predicateString = capturedPredicate.toString();
+            assertTrue(
+                predicateString.contains(qEvent.eventDate.toString()) && predicateString.contains(
+                    plusTwoHours.toString()), // loe(plusTwoHours)
+                "Предикат должен содержать фильтр по конечной дате");
+            verify(eventRepository).findAll(capturedPredicate, pageable);
+        }
+
+        @Test
+        @DisplayName("Должен передавать null предикат в репозиторий, если фильтры не заданы")
+        void getEventsAdmin_withNoFilters_shouldPassNullPredicateIfBuilderIsEmpty() {
+            Pageable pageable = PageRequest.of(0, 10, Sort.by(Sort.Direction.ASC, "id"));
+            Page<Event> emptyPage = new PageImpl<>(Collections.emptyList(), pageable, 0);
+
+            when(eventRepository.findAll(isNull(Predicate.class), eq(pageable))).thenReturn(
+                emptyPage);
+
+            eventService.getEventsAdmin(null, null, null, null, null, 0, 10);
+
+            verify(eventRepository).findAll(isNull(Predicate.class), eq(pageable));
+        }
+
+        @Test
+        @DisplayName("Должен корректно формировать предикат со всеми фильтрами одновременно")
+        void getEventsAdmin_withAllFilters_shouldApplyAllPredicates() {
+            List<Long> users = List.of(1L);
+            List<EventState> states = List.of(EventState.PUBLISHED);
+            List<Long> categories = List.of(10L);
+            LocalDateTime rangeStart = now;
+            LocalDateTime rangeEnd = plusTwoHours;
+            Pageable pageable = PageRequest.of(0, 10, Sort.by(Sort.Direction.ASC, "id"));
+            Page<Event> emptyPage = new PageImpl<>(Collections.emptyList(), pageable, 0);
+
+            when(eventRepository.findAll(predicateCaptor.capture(), eq(pageable))).thenReturn(
+                emptyPage);
+
+            eventService.getEventsAdmin(users, states, categories, rangeStart, rangeEnd, 0, 10);
+
+            Predicate capturedPredicate = predicateCaptor.getValue();
+            assertNotNull(capturedPredicate);
+            String predicateString = capturedPredicate.toString();
+
+            String initiatorIdPath = qEvent.initiator.id.toString();
+            String statePath = qEvent.state.toString();
+            String categoryIdPath = qEvent.category.id.toString();
+            String eventDatePath = qEvent.eventDate.toString();
+
+            assertAll("Проверка всех частей предиката", () -> assertTrue(
+                predicateString.contains(initiatorIdPath + " = " + users.getFirst()),
+                "Фильтр по пользователям"), () -> assertTrue(
+                predicateString.contains(statePath + " = " + states.getFirst().toString()),
+                "Фильтр по состояниям"), () -> assertTrue(
+                predicateString.contains(categoryIdPath + " = " + categories.getFirst()),
+                "Фильтр по категориям"), () -> assertTrue(
+                predicateString.contains(eventDatePath + " >= " + rangeStart.toString()),
+                "Фильтр по начальной дате"), () -> assertTrue(
+                predicateString.contains(eventDatePath + " <= " + rangeEnd.toString()),
+                "Фильтр по конечной дате"));
+            verify(eventRepository).findAll(capturedPredicate, pageable);
+        }
+    }
+
+    // ... TODO: Добавить тесты для других методов EventService, когда они появятся ...
+}

--- a/pom.xml
+++ b/pom.xml
@@ -23,6 +23,7 @@
 		<testcontainers.version>1.21.0</testcontainers.version>
 		<mockito.version>5.14.2</mockito.version>
 		<querydsl.version>5.1.0</querydsl.version>
+		<org.mapstruct.version>1.6.3</org.mapstruct.version>
 		<maven.compiler.source>${java.version}</maven.compiler.source>
 		<maven.compiler.target>${java.version}</maven.compiler.target>
 	</properties>
@@ -141,8 +142,12 @@
 				<groupId>com.querydsl</groupId>
 				<artifactId>querydsl-apt</artifactId>
 				<version>${querydsl.version}</version>
-				<scope>provided</scope>
 				<classifier>jakarta</classifier>
+			</dependency>
+			<dependency>
+				<groupId>org.mapstruct</groupId>
+				<artifactId>mapstruct</artifactId>
+				<version>${org.mapstruct.version}</version>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>
@@ -150,6 +155,48 @@
 	<build>
 		<pluginManagement>
 			<plugins>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-compiler-plugin</artifactId>
+					<configuration>
+						<source>${java.version}</source>
+						<target>${java.version}</target>
+						<annotationProcessorPaths>
+							<path>
+								<groupId>org.projectlombok</groupId>
+								<artifactId>lombok</artifactId>
+								<version>${lombok.version}</version>
+							</path>
+							<path>
+								<groupId>org.projectlombok</groupId>
+								<artifactId>lombok-mapstruct-binding</artifactId>
+								<version>0.2.0</version>
+							</path>
+							<path>
+								<groupId>org.mapstruct</groupId>
+								<artifactId>mapstruct-processor</artifactId>
+								<version>${org.mapstruct.version}</version>
+							</path>
+							<path>
+								<groupId>com.querydsl</groupId>
+								<artifactId>querydsl-apt</artifactId>
+								<version>${querydsl.version}</version>
+								<classifier>jakarta</classifier>
+							</path>
+							<path>
+								<groupId>jakarta.persistence</groupId>
+								<artifactId>jakarta.persistence-api</artifactId>
+								<version>3.1.0</version>
+							</path>
+							<path>
+								<groupId>jakarta.annotation</groupId>
+								<artifactId>jakarta.annotation-api</artifactId>
+								<version>2.1.1</version>
+							</path>
+						</annotationProcessorPaths>
+						<generatedSourcesDirectory>${project.build.directory}/generated-sources/annotations</generatedSourcesDirectory>
+					</configuration>
+				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-surefire-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -16,14 +16,15 @@
 	<packaging>pom</packaging>
 
 	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<java.version>21</java.version>
 		<spring-boot.version>3.4.5</spring-boot.version>
 		<okhttp3.version>4.12.0</okhttp3.version>
 		<testcontainers.version>1.21.0</testcontainers.version>
 		<mockito.version>5.14.2</mockito.version>
+		<querydsl.version>5.1.0</querydsl.version>
 		<maven.compiler.source>${java.version}</maven.compiler.source>
 		<maven.compiler.target>${java.version}</maven.compiler.target>
-		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>
 
 	<name>Explore With Me</name>
@@ -78,19 +79,9 @@
 				<scope>provided</scope>
 			</dependency>
 			<dependency>
-				<groupId>javax.annotation</groupId>
-				<artifactId>javax.annotation-api</artifactId>
-				<version>1.3.2</version>
-			</dependency>
-			<dependency>
 				<groupId>com.fasterxml.jackson.datatype</groupId>
 				<artifactId>jackson-datatype-jsr310</artifactId>
 				<version>2.19.0</version>
-			</dependency>
-			<dependency>
-				<groupId>javax.validation</groupId>
-				<artifactId>validation-api</artifactId>
-				<version>2.0.1.Final</version>
 			</dependency>
 			<dependency>
 				<groupId>org.jetbrains</groupId>
@@ -124,6 +115,34 @@
 				<artifactId>mockito-inline</artifactId>
 				<version>5.2.0</version>
 				<scope>test</scope>
+			</dependency>
+			<dependency>
+				<groupId>com.querydsl</groupId>
+				<artifactId>querydsl-core</artifactId>
+				<version>${querydsl.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>com.querydsl</groupId>
+				<artifactId>querydsl-jpa</artifactId>
+				<version>${querydsl.version}</version>
+				<classifier>jakarta</classifier>
+			</dependency>
+			<dependency>
+				<groupId>com.querydsl</groupId>
+				<artifactId>querydsl-sql</artifactId>
+				<version>${querydsl.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>com.querydsl</groupId>
+				<artifactId>querydsl-sql-spring</artifactId>
+				<version>${querydsl.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>com.querydsl</groupId>
+				<artifactId>querydsl-apt</artifactId>
+				<version>${querydsl.version}</version>
+				<scope>provided</scope>
+				<classifier>jakarta</classifier>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>

--- a/stats-service/stats-server/pom.xml
+++ b/stats-service/stats-server/pom.xml
@@ -71,6 +71,19 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <annotationProcessorPaths>
+            <path>
+              <groupId>org.projectlombok</groupId>
+              <artifactId>lombok</artifactId>
+              <version>${lombok.version}</version>
+            </path>
+          </annotationProcessorPaths>
+        </configuration>
+      </plugin>
+      <plugin>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-maven-plugin</artifactId>
       </plugin>


### PR DESCRIPTION
## Описание

Данный Pull Request реализует эндпоинт для администраторов (`GET /admin/events`) для поиска и фильтрации событий с использованием различных критериев и пагинации.

### Ключевые изменения:

1.  **Репозиторий (`EventRepository`):**
    *   Расширен `QuerydslPredicateExecutor` для поддержки динамических запросов.
    *   Реализована логика построения предиката QueryDSL в `EventServiceImpl` для фильтрации по:
        *   ID пользователей (`users`)
        *   Состояниям событий (`states`)
        *   ID категорий (`categories`)
        *   Диапазону дат (`rangeStart`, `rangeEnd`)
2.  **Сервисный слой (`EventServiceImpl`):**
    *   Реализован метод `getEventsAdmin(...)`, использующий `EventRepository` с QueryDSL для получения отфильтрованных и пагинированных событий.
    *   Добавлен `EventMapper` (с использованием MapStruct) для преобразования `Event` в `EventFullDto`.
        *   *Примечание:* Поля `confirmedRequests` и `views` в `EventFullDto` для данного эндпоинта пока возвращают значения-заглушки (0). Их полноценный расчет будет реализован в задачах, связанных с публичным API и подсчетом запросов на участие.
3.  **Контроллер (`AdminEventController`):**
    *   Реализован эндпоинт `GET /admin/events`, принимающий все необходимые параметры фильтрации и пагинации.
4.  **DTO:**
    *   Создан `EventFullDto`.
    *   Использованы временные стабы для `UserShortDto` и `CategoryDto` для обеспечения возможности разработки (финальные версии DTO будут предоставлены в рамках других задач).
5.  **Тестирование:**
    *   **Юнит-тесты:** Добавлены для `EventMapper`, `EventServiceImpl` и `AdminEventController`.
    *   **Интеграционные тесты:** Добавлены для `EventRepository` (`@DataJpaTest` с Testcontainers) для проверки корректности QueryDSL запросов и фильтрации.

### Как проверить:

1.  Убедиться, что проект собирается: `mvn clean install`.
2.  Запустить сервисы: `docker-compose up --build main-service ewm-db`.
3.  Отправить GET-запросы на `http://localhost:8080/admin/events` с различными комбинациями параметров:
    *   Без параметров (пагинация по умолчанию).
    *   `users={id1},{id2}`
    *   `states={PENDING},{PUBLISHED}`
    *   `categories={id1},{id2}`
    *   `rangeStart={yyyy-MM-dd HH:mm:ss}`
    *   `rangeEnd={yyyy-MM-dd HH:mm:ss}`
    *   `from={value}`, `size={value}`
    *   Комбинации вышеуказанных параметров.
    Ожидается список `EventFullDto` или пустой список, соответствующий критериям фильтрации.