### PR TITLE
Публичные API событий и интеграция StatsClient

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,15 @@
 
 - [Технологии](#технологии)
 - [Структура проекта](#структура-проекта)
+- [API Спецификации](#api-спецификации)
 - [Начало работы](#начало-работы)
     - [Предварительные требования](#предварительные-требования)
     - [Сборка проекта](#сборка-проекта)
     - [Запуск с использованием Docker Compose](#запуск-с-использованием-docker-compose)
     - [Локальный запуск для разработки (IntelliJ IDEA)](#локальный-запуск-для-разработки-intellij-idea)
-        - [Локальный запуск Stats Service](#локальный-запуск-stats-service)
-        - [Локальный запуск Main Service](#локальный-запуск-main-service)
+        - [Локальный запуск Stats Service](#локальный-запуск-stats-service-stats-server)
+        - [Локальный запуск Main Service](#локальный-запуск-main-service-main-service)
+- [Примеры использования API (публичные эндпоинты)](#примеры-использования-api-публичные-эндпоинты)
 - [Тестирование](#тестирование)
 - [Дополнительная функциональность](#дополнительная-функциональность)
 - [Планы по использованию OpenAPI Generator](#планы-по-использованию-openapi-generator)
@@ -21,13 +23,14 @@
 ## Технологии
 
 - Java 21
-- Spring Boot 3.4.5 # Убедитесь, что версия актуальна (в вашем корневом pom.xml указана эта версия)
-- Spring Data JPA
-- Spring MVC
-- PostgreSQL 16.1 # Можно уточнить версию PostgreSQL
+- Spring Boot 3.4.5 # Убедитесь, что версия актуальна
+- Spring Data JPA, QueryDSL
+- Spring MVC, Spring AOP (для интеграции со StatsClient)
+- PostgreSQL 16.1
 - Maven
 - Docker / Docker Compose
 - Lombok
+- MapStruct (для маппинга DTO)
 - JUnit 5, Mockito
 - Testcontainers
 - Checkstyle, Spotbugs, Jacoco (для контроля качества кода)
@@ -37,14 +40,23 @@
 Проект является многомодульным Maven-проектом и состоит из следующих основных частей:
 
 - `explore-with-me` (корневой POM)
-    - `ewm-common`: Общий модуль, содержащий классы, используемые как основным сервисом, так и сервисом статистики (например, `ApiError.java`).
-    - `main-service`: Основной сервис приложения. Отвечает за бизнес-логику, управление пользователями, событиями, категориями, подборками и запросами на участие.
+    - `ewm-common`: Общий модуль, содержащий классы, используемые как основным сервисом, так и сервисом статистики (например, `ApiError.java`, общие константы).
+    - `main-service`: Основной сервис приложения. Отвечает за бизнес-логику, управление пользователями, событиями, категориями, подборками и запросами на участие. Взаимодействует с `stats-client` для сбора статистики.
         - `Dockerfile`
+        - `schema.sql` (для инициализации схемы БД `ewm_main_db`)
     - `stats-service` (родительский POM для модулей статистики)
         - `stats-dto`: Data Transfer Objects (DTO) для сервиса статистики.
-        - `stats-client`: HTTP-клиент для взаимодействия с сервисом статистики (используется `main-service`).
-        - `stats-server`: Сервис статистики (сбор и предоставление данных о запросах к эндпоинтам).
-            - `Dockerfile`
+        *   `stats-client`: HTTP-клиент для взаимодействия с API сервиса статистики (используется `main-service`).
+        *   `stats-server`: Сервис статистики (сбор и предоставление данных о запросах к эндпоинтам).
+            *   `Dockerfile`
+            *   `schema.sql` (для инициализации схемы БД `ewm_stats_db`)
+
+## API Спецификации
+
+-   [Спецификация основного сервиса (ewm-main-service-spec.json)](https://raw.githubusercontent.com/yandex-praktikum/java-explore-with-me/main/ewm-main-service-spec.json)
+-   [Спецификация сервиса статистики (ewm-stats-service.json)](https://raw.githubusercontent.com/yandex-praktikum/java-explore-with-me/main/ewm-stats-service-spec.json)
+
+*Рекомендуется просматривать через Swagger Editor или аналогичный инструмент.*
 
 ## Начало работы
 
@@ -52,45 +64,37 @@
 
 Для работы с проектом вам понадобятся:
 
-- JDK 21 (или выше, совместимая с Java 21)
+- JDK 21
 - Apache Maven 3.6+
 - Docker и Docker Compose
-- IntelliJ IDEA (рекомендуется) или другая IDE с поддержкой Maven и Spring Boot.
+- IntelliJ IDEA (рекомендуется)
 
 ### Сборка проекта
 
-Для сборки всех модулей проекта выполните следующую команду в корневой директории:
-
+Для сборки всех модулей проекта (включая генерацию Q-типов QueryDSL и реализаций MapStruct) выполните:
 ```bash
 mvn clean install
 ```
-Эта команда также запустит статические анализаторы кода (Checkstyle, Spotbugs) и юнит-тесты.
+Эта команда также запустит статические анализаторы кода и юнит-тесты.
 
 ### Запуск с использованием Docker Compose
 
-Наиболее предпочтительный способ запуска всего приложения – использование Docker Compose. Это обеспечит запуск всех сервисов (`main-service`, `stats-server`) и их соответствующих баз данных PostgreSQL в изолированных контейнерах.
+Это основной способ запуска всего приложения для проверки взаимодействия сервисов.
 
-1.  **Соберите проект (если не делали ранее):**
-    ```bash
-    mvn clean install
-    ```
+1.  **Соберите проект:** `mvn clean install`
 2.  **Запустите сервисы:**
     В корневой директории проекта выполните:
     ```bash
     docker-compose up --build -d
     ```
-    Ключ `-d` запускает контейнеры в фоновом режиме.
-    Эта команда соберет Docker-образы для `stats-server` и `main-service` и запустит их вместе с необходимыми базами данных PostgreSQL.
-    - Сервис статистики (`stats-server`) будет доступен по адресу: `http://localhost:9090`
-    - Основной сервис (`main-service`) будет доступен по адресу: `http://localhost:8080`
+    - Сервис статистики (`stats-server`): `http://localhost:9090`
+    - Основной сервис (`main-service`): `http://localhost:8080`
 
-3.  **Просмотр логов (при запуске с `-d`):**
+3.  **Просмотр логов:**
     ```bash
     docker-compose logs -f main-service
     docker-compose logs -f stats-server
-    # или docker-compose logs -f для всех сервисов
     ```
-
 4.  **Остановка сервисов:**
     ```bash
     docker-compose down
@@ -99,73 +103,79 @@ mvn clean install
     ```bash
     docker-compose down -v
     ```
+    *Примечание: При первом запуске `docker-compose up` скрипты `schema.sql` из каждого сервиса будут выполнены для создания таблиц в соответствующих базах данных.*
 
 ### Локальный запуск для разработки (IntelliJ IDEA)
 
-Для удобства разработки и отладки можно запускать сервисы локально из IntelliJ IDEA.
+#### Локальный запуск Stats Service (`stats-server`)
 
-#### Локальный запуск Stats Service
+Предусмотрен профиль запуска `stat-local` в IntelliJ IDEA.
 
-Предусмотрен профиль запуска `stat-local` в IntelliJ IDEA для `stats-server`.
-
-1.  **Настройка базы данных для `stats-server`:**
-    Убедитесь, что у вас локально запущен экземпляр PostgreSQL, доступный по адресу, указанному в `stats-service/stats-server/src/main/resources/application-local.yml`.
-    Примерные параметры для `application-local.yml`:
+1.  **База данных для `stats-server`:** Настройте локальный PostgreSQL согласно `stats-service/stats-server/src/main/resources/application-local.yml` (порт, имя БД, пользователь, пароль).
     ```yaml
+    # stats-service/stats-server/src/main/resources/application-local.yml
     spring:
       datasource:
-        url: jdbc:postgresql://localhost:6543/ewm_stats_db # Убедитесь, что порт и имя БД соответствуют вашей локальной PG для stats-db
-        username: stats_user # Ваш пользователь
-        password: stats_password # Ваш пароль
+        url: jdbc:postgresql://localhost:6543/ewm_stats_db # Пример
+        username: stats_user
+        password: stats_password
       jpa:
         hibernate:
-          ddl-auto: update # или create-drop для локальной разработки
-    # ... другие настройки, если нужны ...
+          ddl-auto: validate # Используется schema.sql из classpath (src/main/resources)
+      sql:
+        init:
+          mode: always # Для выполнения schema.sql при локальном запуске
     ```
-    *Примечание: Вам может потребоваться создать базу данных `ewm_stats_db` и пользователя `stats_user` вручную, если они еще не существуют.*
+2.  **Запуск `StatsServerApplication`:** Используйте Run Configuration "stat-local" (VM options: `-Dspring.profiles.active=local`).
 
-2.  **Запуск `StatsServerApplication`:**
-    - Откройте проект в IntelliJ IDEA.
-    - Найдите класс `StatsServerApplication.java` в модуле `stats-server`.
-    - В репозитории должна быть предустановленная Run Configuration "stat-local" (проверьте `.idea/runConfigurations/`). Если нет, создайте новую конфигурацию Spring Boot:
-        - **Main class:** `ru.practicum.explorewithme.stats.server.StatsServerApplication`
-        - **VM options:** `-Dspring.profiles.active=local` (активирует `application-local.yml`)
-        - **Working directory:** Корневая директория модуля `stats-server`.
-    - Запустите эту конфигурацию.
+#### Локальный запуск Main Service (`main-service`)
 
-#### Локальный запуск Main Service
+Предусмотрен профиль запуска `main-local` в IntelliJ IDEA.
 
-Аналогично можно настроить локальный запуск для `main-service`.
-
-1.  **Настройка базы данных для `main-service`:**
-    Убедитесь, что у вас локально запущен экземпляр PostgreSQL, доступный по адресу, указанному в `main-service/src/main/resources/application-local.yml`.
-    Создайте файл `application-local.yml` в `main-service/src/main/resources/` (если его еще нет) с примерным содержанием:
+1.  **База данных для `main-service`:** Настройте локальный PostgreSQL согласно `main-service/src/main/resources/application-local.yml`.
     ```yaml
-    # URL сервиса статистики для локального запуска main-service,
-    # если stats-server тоже запущен локально на порту 9090
+    # main-service/src/main/resources/application-local.yml
     stats-server:
-      url: http://localhost:9090
+      url: http://localhost:9090 # Если stats-server тоже запущен локально
 
     spring:
       datasource:
-        url: jdbc:postgresql://localhost:5432/ewm_main_db # Убедитесь, что порт и имя БД соответствуют вашей локальной PG для ewm-db
-        username: ewm_user # Ваш пользователь
-        password: ewm_password # Ваш пароль
+        url: jdbc:postgresql://localhost:5432/ewm_main_db # Пример
+        username: ewm_user
+        password: ewm_password
       jpa:
         hibernate:
-          ddl-auto: update # или create-drop для локальной разработки
-    # ... другие настройки, если нужны ...
+          ddl-auto: validate # Используется schema.sql из classpath
+      sql:
+        init:
+          mode: always # Для выполнения schema.sql при локальном запуске
     ```
-    *Примечание: Вам может потребоваться создать базу данных `ewm_main_db` и пользователя `ewm_user` вручную, если они еще не существуют.*
-    *Также убедитесь, что сервис статистики (`stats-server`) запущен (локально или в Docker), если `main-service` будет к нему обращаться.*
+2.  **Запуск `MainServiceApplication`:** Используйте Run Configuration "main-local" (VM options: `-Dspring.profiles.active=local`). Убедитесь, что `stats-server` уже запущен (локально или в Docker), так как `main-service` от него зависит.
 
-2.  **Запуск `MainServiceApplication`:**
-    - Найдите класс `MainServiceApplication.java` в модуле `main-service`.
-    - В репозитории должна быть предустановленная Run Configuration "main-local" (проверьте `.idea/runConfigurations/`). Если нет, создайте новую конфигурацию Spring Boot:
-        - **Main class:** `ru.practicum.explorewithme.main.MainServiceApplication`
-        - **VM options:** `-Dspring.profiles.active=local` (активирует `application-local.yml`)
-        - **Working directory:** Корневая директория модуля `main-service`. 
-    - Запустите эту конфигурацию.
+## Примеры использования API (публичные эндпоинты)
+
+После запуска `main-service` (например, через Docker Compose на `http://localhost:8080`), вы можете протестировать публичные эндпоинты:
+
+-   **Получение списка событий с фильтрацией:**
+    `GET http://localhost:8080/events?text=концерт&categories=1,2&paid=true&rangeStart=2025-06-01 00:00:00&rangeEnd=2025-06-30 23:59:59&onlyAvailable=true&sort=VIEWS&from=0&size=10`
+    *(Не забудьте URL-кодировать даты и время, если отправляете запрос не через Postman)*
+
+-   **Получение подробной информации о событии:**
+    `GET http://localhost:8080/events/{eventId}` (замените `{eventId}` на ID существующего опубликованного события)
+
+-   **Получение списка категорий:**
+    `GET http://localhost:8080/categories?from=0&size=10`
+
+-   **Получение категории по ID:**
+    `GET http://localhost:8080/categories/{catId}`
+
+-   **Получение списка подборок:**
+    `GET http://localhost:8080/compilations?pinned=true&from=0&size=10`
+
+-   **Получение подборки по ID:**
+    `GET http://localhost:8080/compilations/{compId}`
+
+*(Для админских и приватных эндпоинтов потребуется аутентификация, которая в данном проекте предполагается внешней).*
 
 ## Тестирование
 

--- a/main-service/pom.xml
+++ b/main-service/pom.xml
@@ -64,6 +64,10 @@
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-aop</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
     </dependency>
     <dependency>

--- a/main-service/src/main/java/ru/practicum/explorewithme/main/MainServiceApplication.java
+++ b/main-service/src/main/java/ru/practicum/explorewithme/main/MainServiceApplication.java
@@ -2,8 +2,10 @@ package ru.practicum.explorewithme.main;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.ComponentScan;
 
 @SpringBootApplication
+@ComponentScan(basePackages = {"ru.practicum.explorewithme.main", "ru.practicum.explorewithme.stats.client"})
 public class MainServiceApplication {
     public static void main(String[] args) {
         SpringApplication.run(MainServiceApplication.class, args);

--- a/main-service/src/main/java/ru/practicum/explorewithme/main/MainServiceApplication.java
+++ b/main-service/src/main/java/ru/practicum/explorewithme/main/MainServiceApplication.java
@@ -2,10 +2,11 @@ package ru.practicum.explorewithme.main;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Import;
+import ru.practicum.explorewithme.stats.client.config.StatsClientModuleConfiguration;
 
 @SpringBootApplication
-@ComponentScan(basePackages = {"ru.practicum.explorewithme.main", "ru.practicum.explorewithme.stats.client"})
+@Import(StatsClientModuleConfiguration.class)
 public class MainServiceApplication {
     public static void main(String[] args) {
         SpringApplication.run(MainServiceApplication.class, args);

--- a/main-service/src/main/java/ru/practicum/explorewithme/main/aspect/LogStatsHit.java
+++ b/main-service/src/main/java/ru/practicum/explorewithme/main/aspect/LogStatsHit.java
@@ -1,0 +1,11 @@
+package ru.practicum.explorewithme.main.aspect;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface LogStatsHit {
+}

--- a/main-service/src/main/java/ru/practicum/explorewithme/main/aspect/StatsHitAspect.java
+++ b/main-service/src/main/java/ru/practicum/explorewithme/main/aspect/StatsHitAspect.java
@@ -1,0 +1,64 @@
+package ru.practicum.explorewithme.main.aspect;
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.annotation.AfterReturning;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Pointcut;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+import ru.practicum.explorewithme.stats.client.StatsClient;
+import ru.practicum.explorewithme.stats.dto.EndpointHitDto;
+
+import java.time.LocalDateTime;
+
+@Aspect
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class StatsHitAspect {
+
+    private final StatsClient statsClient;
+
+    @Value("${spring.application.name:ewm-main-service}")
+    private String appName;
+
+    @Pointcut("@annotation(LogStatsHit)")
+    public void methodsToLogHit() {
+    }
+
+    @AfterReturning(pointcut = "methodsToLogHit()")
+    public void logHit(JoinPoint joinPoint) {
+        ServletRequestAttributes attributes = (ServletRequestAttributes) RequestContextHolder.getRequestAttributes();
+        if (attributes == null) {
+            log.warn("Cannot log hit: HttpServletRequest is not available in the current context for method: {}",
+                joinPoint.getSignature().toShortString());
+            return;
+        }
+        HttpServletRequest request = attributes.getRequest();
+
+        String uri = request.getRequestURI();
+        String ip = request.getRemoteAddr();
+        LocalDateTime timestamp = LocalDateTime.now();
+
+        log.debug("StatsHitAspect: Logging hit for app='{}', uri='{}', ip='{}'", appName, uri, ip);
+
+        EndpointHitDto hitDto = EndpointHitDto.builder()
+            .app(appName)
+            .uri(uri)
+            .ip(ip)
+            .timestamp(timestamp)
+            .build();
+
+        try {
+            statsClient.saveHit(hitDto);
+            log.debug("StatsHitAspect: Hit successfully sent to stats service for URI: {}", uri);
+        } catch (Exception e) {
+            log.error("StatsHitAspect: Failed to send hit to stats service for URI: {}. Error: {}", uri, e.getMessage());
+        }
+    }
+}

--- a/main-service/src/main/java/ru/practicum/explorewithme/main/aspect/StatsHitAspect.java
+++ b/main-service/src/main/java/ru/practicum/explorewithme/main/aspect/StatsHitAspect.java
@@ -9,6 +9,7 @@ import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.annotation.Pointcut;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
 import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.context.request.ServletRequestAttributes;
 import ru.practicum.explorewithme.stats.client.StatsClient;
@@ -42,7 +43,17 @@ public class StatsHitAspect {
         HttpServletRequest request = attributes.getRequest();
 
         String uri = request.getRequestURI();
-        String ip = request.getRemoteAddr();
+
+        String ip;
+        String xRealIp = request.getHeader("X-Real-IP");
+        if (StringUtils.hasText(xRealIp)) { // StringUtils.hasText проверяет на null, "", "   "
+            ip = xRealIp;
+            log.debug("StatsHitAspect: Using IP from X-Real-IP header: {}", ip);
+        } else {
+            ip = request.getRemoteAddr();
+            log.debug("StatsHitAspect: X-Real-IP header not found or empty, using remoteAddr: {}", ip);
+        }
+
         LocalDateTime timestamp = LocalDateTime.now();
 
         log.debug("StatsHitAspect: Logging hit for app='{}', uri='{}', ip='{}'", appName, uri, ip);

--- a/main-service/src/main/java/ru/practicum/explorewithme/main/controller/pub/PublicEventController.java
+++ b/main-service/src/main/java/ru/practicum/explorewithme/main/controller/pub/PublicEventController.java
@@ -8,6 +8,7 @@ import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
+import ru.practicum.explorewithme.main.aspect.LogStatsHit;
 import ru.practicum.explorewithme.main.dto.EventFullDto;
 import ru.practicum.explorewithme.main.dto.EventShortDto;
 import ru.practicum.explorewithme.main.service.EventService;
@@ -29,6 +30,7 @@ public class PublicEventController {
 
     @GetMapping
     @ResponseStatus(HttpStatus.OK)
+    @LogStatsHit
     public List<EventShortDto> getEvents(
             @RequestParam(name = "text", required = false) String text,
             @RequestParam(name = "categories", required = false) List<Long> categories,
@@ -64,6 +66,7 @@ public class PublicEventController {
 
     @GetMapping("/{eventId}")
     @ResponseStatus(HttpStatus.OK)
+    @LogStatsHit
     public EventFullDto getEventById(
             @PathVariable @Positive Long eventId,
             @RequestHeader(name = "X-Real-IP", required = false) String ipAddress) {

--- a/main-service/src/main/java/ru/practicum/explorewithme/main/controller/pub/PublicEventController.java
+++ b/main-service/src/main/java/ru/practicum/explorewithme/main/controller/pub/PublicEventController.java
@@ -59,7 +59,7 @@ public class PublicEventController {
                 .sort(sort)
                 .build();
 
-        List<EventShortDto> events = eventService.getEventsPublic(params, from, size, ipAddress);
+        List<EventShortDto> events = eventService.getEventsPublic(params, from, size);
         log.info("Public: Found {} events", events.size());
         return events;
     }
@@ -71,7 +71,7 @@ public class PublicEventController {
             @PathVariable @Positive Long eventId,
             @RequestHeader(name = "X-Real-IP", required = false) String ipAddress) {
         log.info("Public: Received request to get event with id={}", eventId);
-        EventFullDto event = eventService.getEventByIdPublic(eventId, ipAddress);
+        EventFullDto event = eventService.getEventByIdPublic(eventId);
         log.info("Public: Found event: {}", event);
         return event;
     }

--- a/main-service/src/main/java/ru/practicum/explorewithme/main/dto/NewEventDto.java
+++ b/main-service/src/main/java/ru/practicum/explorewithme/main/dto/NewEventDto.java
@@ -2,6 +2,7 @@ package ru.practicum.explorewithme.main.dto;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import jakarta.validation.constraints.Future;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.PositiveOrZero;
@@ -34,6 +35,7 @@ public class NewEventDto {
     String description;
 
     @NotNull(message = "Поле eventDate не может быть пустым")
+    @Future(message = "Поле eventDate должно быть в будущем")
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = DATE_TIME_FORMAT_PATTERN)
     LocalDateTime eventDate;
 

--- a/main-service/src/main/java/ru/practicum/explorewithme/main/dto/UpdateEventAdminRequestDto.java
+++ b/main-service/src/main/java/ru/practicum/explorewithme/main/dto/UpdateEventAdminRequestDto.java
@@ -3,6 +3,7 @@ package ru.practicum.explorewithme.main.dto;
 import static ru.practicum.explorewithme.common.constants.DateTimeConstants.DATE_TIME_FORMAT_PATTERN;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import jakarta.validation.constraints.Future;
 import jakarta.validation.constraints.PositiveOrZero;
 import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
@@ -28,6 +29,7 @@ public class UpdateEventAdminRequestDto {
     private String description;
 
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = DATE_TIME_FORMAT_PATTERN)
+    @Future(message = "Event date must be in the future")
     private LocalDateTime eventDate;
 
     private Location location;

--- a/main-service/src/main/java/ru/practicum/explorewithme/main/dto/UpdateEventUserRequestDto.java
+++ b/main-service/src/main/java/ru/practicum/explorewithme/main/dto/UpdateEventUserRequestDto.java
@@ -3,6 +3,7 @@ package ru.practicum.explorewithme.main.dto;
 import static ru.practicum.explorewithme.common.constants.DateTimeConstants.DATE_TIME_FORMAT_PATTERN;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import jakarta.validation.constraints.Future;
 import jakarta.validation.constraints.PositiveOrZero;
 import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
@@ -28,6 +29,7 @@ public class UpdateEventUserRequestDto {
     private String description;
 
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = DATE_TIME_FORMAT_PATTERN)
+    @Future(message = "Event date must be in the future")
     private LocalDateTime eventDate;
 
     private Location location;

--- a/main-service/src/main/java/ru/practicum/explorewithme/main/mapper/EventMapper.java
+++ b/main-service/src/main/java/ru/practicum/explorewithme/main/mapper/EventMapper.java
@@ -14,7 +14,8 @@ public interface EventMapper {
 
     @Mappings({
         @Mapping(source = "category", target = "category"),
-        @Mapping(source = "initiator", target = "initiator")
+        @Mapping(source = "initiator", target = "initiator"),
+        @Mapping(source = "confirmedRequestsCount", target = "confirmedRequests")
     })
     EventFullDto toEventFullDto(Event event);
 
@@ -31,7 +32,7 @@ public interface EventMapper {
     @Mappings({
         @Mapping(source = "category", target = "category"),
         @Mapping(source = "initiator", target = "initiator"),
-        @Mapping(target = "confirmedRequests", ignore = true),
+        @Mapping(source = "confirmedRequestsCount", target = "confirmedRequests"),
         @Mapping(target = "views", ignore = true)
     })
     EventShortDto toEventShortDto(Event event);

--- a/main-service/src/main/java/ru/practicum/explorewithme/main/mapper/EventMapper.java
+++ b/main-service/src/main/java/ru/practicum/explorewithme/main/mapper/EventMapper.java
@@ -14,9 +14,7 @@ public interface EventMapper {
 
     @Mappings({
         @Mapping(source = "category", target = "category"),
-        @Mapping(source = "initiator", target = "initiator"),
-        @Mapping(target = "confirmedRequests", expression = "java(0L)"), // Заглушка
-        @Mapping(target = "views", expression = "java(0L)") // Заглушка
+        @Mapping(source = "initiator", target = "initiator")
     })
     EventFullDto toEventFullDto(Event event);
 
@@ -32,9 +30,7 @@ public interface EventMapper {
 
     @Mappings({
         @Mapping(source = "category", target = "category"),
-        @Mapping(source = "initiator", target = "initiator"),
-        @Mapping(target = "confirmedRequests", expression = "java(0L)"), // Заглушка
-        @Mapping(target = "views", expression = "java(0L)") // Заглушка
+        @Mapping(source = "initiator", target = "initiator")
     })
     EventShortDto toEventShortDto(Event event);
 

--- a/main-service/src/main/java/ru/practicum/explorewithme/main/mapper/EventMapper.java
+++ b/main-service/src/main/java/ru/practicum/explorewithme/main/mapper/EventMapper.java
@@ -30,7 +30,9 @@ public interface EventMapper {
 
     @Mappings({
         @Mapping(source = "category", target = "category"),
-        @Mapping(source = "initiator", target = "initiator")
+        @Mapping(source = "initiator", target = "initiator"),
+        @Mapping(target = "confirmedRequests", ignore = true),
+        @Mapping(target = "views", ignore = true)
     })
     EventShortDto toEventShortDto(Event event);
 

--- a/main-service/src/main/java/ru/practicum/explorewithme/main/model/Event.java
+++ b/main-service/src/main/java/ru/practicum/explorewithme/main/model/Event.java
@@ -6,6 +6,7 @@ import lombok.*;
 import java.time.LocalDateTime;
 import java.util.HashSet;
 import java.util.Set;
+import org.hibernate.annotations.Formula;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
@@ -116,5 +117,11 @@ public class Event {
     @ManyToMany(mappedBy = "events")
     @Builder.Default
     private Set<Compilation> compilations = new HashSet<>();
+
+    /**
+     *  Количество подтверждённых заявок
+     */
+    @Formula("(SELECT COUNT(r.id) FROM requests r WHERE r.event_id = id AND r.status = 'CONFIRMED')")
+    private Long confirmedRequestsCount;
 
 }

--- a/main-service/src/main/java/ru/practicum/explorewithme/main/repository/EventRepository.java
+++ b/main-service/src/main/java/ru/practicum/explorewithme/main/repository/EventRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.querydsl.QuerydslPredicateExecutor;
 import ru.practicum.explorewithme.main.model.Event;
+import ru.practicum.explorewithme.main.model.EventState;
 
 public interface EventRepository extends JpaRepository<Event, Long>, QuerydslPredicateExecutor<Event> {
     Page<Event> findByInitiatorId(Long userId, Pageable pageable);
@@ -15,5 +16,7 @@ public interface EventRepository extends JpaRepository<Event, Long>, QuerydslPre
     boolean existsByCategoryId(Long categoryId);
 
     boolean existsByIdAndInitiator_Id(Long id, Long initiatorId);
+
+    Optional<Event> findByIdAndState(Long eventId, EventState state);
 
 }

--- a/main-service/src/main/java/ru/practicum/explorewithme/main/repository/RequestRepository.java
+++ b/main-service/src/main/java/ru/practicum/explorewithme/main/repository/RequestRepository.java
@@ -1,5 +1,6 @@
 package ru.practicum.explorewithme.main.repository;
 
+import java.util.Set;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -34,4 +35,17 @@ public interface RequestRepository extends JpaRepository<ParticipationRequest, L
     List<ParticipationRequest> findByEvent_IdAndStatus(Long eventId, RequestStatus status);
 
     List<ParticipationRequest> findByEvent_Id(Long eventId);
+
+    long countByEventIdAndStatus(Long eventId, RequestStatus status);
+
+    @Query("SELECT r.event.id as eventId, COUNT(r.id) as requestCount " +
+        "FROM ParticipationRequest r " +
+        "WHERE r.event.id IN :eventIds AND r.status = 'CONFIRMED' " +
+        "GROUP BY r.event.id")
+    List<ConfirmedRequestCountProjection> countConfirmedRequestsForEventIds(@Param("eventIds") Set<Long> eventIds);
+
+    interface ConfirmedRequestCountProjection {
+        Long getEventId();
+        Long getRequestCount();
+    }
 }

--- a/main-service/src/main/java/ru/practicum/explorewithme/main/repository/RequestRepository.java
+++ b/main-service/src/main/java/ru/practicum/explorewithme/main/repository/RequestRepository.java
@@ -46,6 +46,7 @@ public interface RequestRepository extends JpaRepository<ParticipationRequest, L
 
     interface ConfirmedRequestCountProjection {
         Long getEventId();
+
         Long getRequestCount();
     }
 }

--- a/main-service/src/main/java/ru/practicum/explorewithme/main/service/EventService.java
+++ b/main-service/src/main/java/ru/practicum/explorewithme/main/service/EventService.java
@@ -26,7 +26,7 @@ public interface EventService {
 
     EventFullDto moderateEventByAdmin(Long eventId, UpdateEventAdminRequestDto requestDto);
 
-    List<EventShortDto> getEventsPublic(PublicEventSearchParams params, int from, int size, String ipAddress);
+    List<EventShortDto> getEventsPublic(PublicEventSearchParams params, int from, int size);
 
-    EventFullDto getEventByIdPublic(Long eventId, String ipAddress);
+    EventFullDto getEventByIdPublic(Long eventId);
 }

--- a/main-service/src/main/java/ru/practicum/explorewithme/main/service/EventServiceImpl.java
+++ b/main-service/src/main/java/ru/practicum/explorewithme/main/service/EventServiceImpl.java
@@ -121,6 +121,9 @@ public class EventServiceImpl implements EventService {
         Map<Long, Long> viewsMap = getViewsForEvents(foundEvents);
         Map<Long, Long> confirmedRequestsMap = getConfirmedRequestsForEvents(foundEvents);
 
+        Map<Long, Event> eventMapById = foundEvents.stream()
+            .collect(Collectors.toMap(Event::getId, e -> e));
+
         List<EventShortDto> eventDtos = foundEvents.stream()
             .map(event -> {
                 EventShortDto dto = eventMapper.toEventShortDto(event);
@@ -133,7 +136,7 @@ public class EventServiceImpl implements EventService {
         if (onlyAvailable) {
             eventDtos = eventDtos.stream()
                 .filter(dto -> {
-                    Event event = foundEvents.stream().filter(e -> e.getId().equals(dto.getId())).findFirst().orElse(null);
+                    Event event = eventMapById.get(dto.getId()); // Быстрый доступ
                     if (event == null) return false;
                     return event.getParticipantLimit() == 0 || dto.getConfirmedRequests() < event.getParticipantLimit();
                 })

--- a/main-service/src/main/java/ru/practicum/explorewithme/main/service/EventServiceImpl.java
+++ b/main-service/src/main/java/ru/practicum/explorewithme/main/service/EventServiceImpl.java
@@ -299,6 +299,14 @@ public class EventServiceImpl implements EventService {
         }
 
         List<EventFullDto> result = eventMapper.toEventFullDtoList(eventPage.getContent());
+
+        Map<Long, Long> viewsData = getViewsForEvents(eventPage.getContent());
+        Map<Long, Long> confirmedRequestsData = getConfirmedRequestsForEvents(eventPage.getContent());
+        result.forEach(dto -> {
+            dto.setViews(viewsData.get(dto.getId()));
+            dto.setConfirmedRequests(confirmedRequestsData.get(dto.getId()));
+        });
+
         log.debug("Admin search found {} events on page {}/{}", result.size(), pageable.getPageNumber(), eventPage.getTotalPages());
         return result;
     }

--- a/main-service/src/main/java/ru/practicum/explorewithme/main/service/EventServiceImpl.java
+++ b/main-service/src/main/java/ru/practicum/explorewithme/main/service/EventServiceImpl.java
@@ -61,8 +61,8 @@ public class EventServiceImpl implements EventService {
 
     @Override
     @Transactional(readOnly = true)
-    public List<EventShortDto> getEventsPublic(PublicEventSearchParams params, int from, int size, String ipAddress) {
-        log.info("Public search for events with params: {}, from={}, size={}, ip={}", params, from, size, ipAddress);
+    public List<EventShortDto> getEventsPublic(PublicEventSearchParams params, int from, int size) {
+        log.info("Public search for events with params: {}, from={}, size={}", params, from, size);
 
         String text = params.getText();
         List<Long> categories = params.getCategories();
@@ -205,8 +205,8 @@ public class EventServiceImpl implements EventService {
 
     @Override
     @Transactional(readOnly = true)
-    public EventFullDto getEventByIdPublic(Long eventId, String ipAddress) {
-        log.info("Public: Fetching event id={} from IP={}", eventId, ipAddress);
+    public EventFullDto getEventByIdPublic(Long eventId) {
+        log.info("Public: Fetching event id={}", eventId);
 
         Event event = eventRepository.findByIdAndState(eventId, EventState.PUBLISHED)
             .orElseThrow(() -> new EntityNotFoundException(

--- a/main-service/src/main/java/ru/practicum/explorewithme/main/service/EventServiceImpl.java
+++ b/main-service/src/main/java/ru/practicum/explorewithme/main/service/EventServiceImpl.java
@@ -106,9 +106,7 @@ public class EventServiceImpl implements EventService {
             }
         }
 
-        Sort sortOption = sort != null && sort.equalsIgnoreCase("VIEWS") ?
-                Sort.by(Sort.Direction.DESC, "views") :
-                Sort.by(Sort.Direction.ASC, "eventDate");
+        Sort sortOption = Sort.by(Sort.Direction.ASC, "eventDate");
 
         Pageable pageable = PageRequest.of(from / size, size, sortOption);
 
@@ -140,6 +138,10 @@ public class EventServiceImpl implements EventService {
                     return event.getParticipantLimit() == 0 || dto.getConfirmedRequests() < event.getParticipantLimit();
                 })
                 .collect(Collectors.toList());
+        }
+
+        if (sort != null && sort.equalsIgnoreCase("VIEWS")) {
+            eventDtos.sort(Comparator.comparing(EventShortDto::getViews).reversed());
         }
 
         log.info("Public search prepared {} DTOs after enrichment and filtering.", eventDtos.size());

--- a/main-service/src/main/java/ru/practicum/explorewithme/main/service/EventServiceImpl.java
+++ b/main-service/src/main/java/ru/practicum/explorewithme/main/service/EventServiceImpl.java
@@ -5,8 +5,14 @@ import com.querydsl.core.BooleanBuilder;
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
 import java.util.List;
 
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -27,12 +33,16 @@ import ru.practicum.explorewithme.main.model.Category;
 import ru.practicum.explorewithme.main.model.Event;
 import ru.practicum.explorewithme.main.model.EventState;
 import ru.practicum.explorewithme.main.model.QEvent;
+import ru.practicum.explorewithme.main.model.RequestStatus;
 import ru.practicum.explorewithme.main.model.User;
 import ru.practicum.explorewithme.main.repository.CategoryRepository;
 import ru.practicum.explorewithme.main.repository.EventRepository;
+import ru.practicum.explorewithme.main.repository.RequestRepository;
 import ru.practicum.explorewithme.main.repository.UserRepository;
 import ru.practicum.explorewithme.main.service.params.AdminEventSearchParams;
 import ru.practicum.explorewithme.main.service.params.PublicEventSearchParams;
+import ru.practicum.explorewithme.stats.client.StatsClient;
+import ru.practicum.explorewithme.stats.dto.ViewStatsDto;
 
 @Service
 @RequiredArgsConstructor
@@ -44,36 +54,37 @@ public class EventServiceImpl implements EventService {
     private final EventMapper eventMapper;
     private final UserRepository userRepository;
     private final CategoryRepository categoryRepository;
+    private final RequestRepository requestRepository;
+    private final StatsClient statsClient;
 
     private static final long MIN_HOURS_BEFORE_PUBLICATION_FOR_ADMIN = 1;
 
     @Override
     @Transactional(readOnly = true)
     public List<EventShortDto> getEventsPublic(PublicEventSearchParams params, int from, int size, String ipAddress) {
-        log.debug("Public search for events with params: {}", params);
+        log.info("Public search for events with params: {}, from={}, size={}, ip={}", params, from, size, ipAddress);
 
         String text = params.getText();
         List<Long> categories = params.getCategories();
         Boolean paid = params.getPaid();
         LocalDateTime rangeStart = params.getRangeStart();
         LocalDateTime rangeEnd = params.getRangeEnd();
-        boolean onlyAvailable = params.isOnlyAvailable();
+        boolean onlyAvailable = params.isOnlyAvailable(); // У вас был isOnlyAvailable()
         String sort = params.getSort();
 
         if (rangeStart != null && rangeEnd != null && rangeStart.isAfter(rangeEnd)) {
-            throw new IllegalArgumentException("rangeStart cannot be after rangeEnd.");
+            throw new IllegalArgumentException("Validation Error: rangeStart cannot be after rangeEnd.");
         }
 
         QEvent qEvent = QEvent.event;
         BooleanBuilder predicate = new BooleanBuilder();
 
-        // Только опубликованные события
         predicate.and(qEvent.state.eq(EventState.PUBLISHED));
 
         if (text != null && !text.isBlank()) {
             String searchText = text.toLowerCase();
-            predicate.and(qEvent.annotation.lower().contains(searchText)
-                    .or(qEvent.description.lower().contains(searchText)));
+            predicate.and(qEvent.annotation.lower().like("%" + searchText + "%")
+                .or(qEvent.description.lower().like("%" + searchText + "%")));
         }
 
         if (categories != null && !categories.isEmpty()) {
@@ -84,55 +95,154 @@ public class EventServiceImpl implements EventService {
             predicate.and(qEvent.paid.eq(paid));
         }
 
-        if (rangeStart != null) {
-            predicate.and(qEvent.eventDate.goe(rangeStart));
+        if (rangeStart == null && rangeEnd == null) {
+            predicate.and(qEvent.eventDate.after(LocalDateTime.now()));
         } else {
-            predicate.and(qEvent.eventDate.goe(LocalDateTime.now()));
+            if (rangeStart != null) {
+                predicate.and(qEvent.eventDate.goe(rangeStart));
+            }
+            if (rangeEnd != null) {
+                predicate.and(qEvent.eventDate.loe(rangeEnd));
+            }
         }
 
-        if (rangeEnd != null) {
-            predicate.and(qEvent.eventDate.loe(rangeEnd));
-        }
-
-        if (onlyAvailable) {
-            // Заглушка: проверка на доступность (participantLimit > confirmedRequests)
-            predicate.and(qEvent.participantLimit.eq(0));
-        }
-
-        Sort sortOption = sort != null && sort.equals("VIEWS") ?
+        Sort sortOption = sort != null && sort.equalsIgnoreCase("VIEWS") ?
                 Sort.by(Sort.Direction.DESC, "views") :
                 Sort.by(Sort.Direction.ASC, "eventDate");
 
         Pageable pageable = PageRequest.of(from / size, size, sortOption);
 
-        Page<Event> eventPage = eventRepository.findAll(predicate, pageable);
+        Page<Event> eventPage = eventRepository.findAll(predicate.getValue(), pageable);
 
         if (eventPage.isEmpty()) {
             return Collections.emptyList();
         }
 
-        // TODO: Реализовать логику учета просмотров через ipAddress (StatsClient)
-        List<EventShortDto> result = eventMapper.toEventShortDtoList(eventPage.getContent());
-        log.debug("Public search found {} events", result.size());
-        return result;
+        List<Event> foundEvents = eventPage.getContent();
+
+        Map<Long, Long> viewsMap = getViewsForEvents(foundEvents);
+        Map<Long, Long> confirmedRequestsMap = getConfirmedRequestsForEvents(foundEvents);
+
+        List<EventShortDto> eventDtos = foundEvents.stream()
+            .map(event -> {
+                EventShortDto dto = eventMapper.toEventShortDto(event);
+                dto.setViews(viewsMap.getOrDefault(event.getId(), 0L));
+                dto.setConfirmedRequests(confirmedRequestsMap.getOrDefault(event.getId(), 0L));
+                return dto;
+            })
+            .collect(Collectors.toList());
+
+        if (onlyAvailable) {
+            eventDtos = eventDtos.stream()
+                .filter(dto -> {
+                    Event event = foundEvents.stream().filter(e -> e.getId().equals(dto.getId())).findFirst().orElse(null);
+                    if (event == null) return false;
+                    return event.getParticipantLimit() == 0 || dto.getConfirmedRequests() < event.getParticipantLimit();
+                })
+                .collect(Collectors.toList());
+        }
+
+        log.info("Public search prepared {} DTOs after enrichment and filtering.", eventDtos.size());
+        return eventDtos;
+    }
+
+    private Map<Long, Long> getViewsForEvents(List<Event> events) {
+        if (events == null || events.isEmpty()) {
+            return Collections.emptyMap();
+        }
+        List<String> uris = events.stream()
+            .map(event -> "/events/" + event.getId())
+            .distinct()
+            .collect(Collectors.toList());
+
+        LocalDateTime earliestCreation = events.stream()
+            .map(Event::getCreatedOn)
+            .min(LocalDateTime::compareTo)
+            .orElse(LocalDateTime.of(1970, 1, 1, 0, 0));
+
+        Map<Long, Long> viewsMap = new HashMap<>();
+        try {
+            List<ViewStatsDto> stats = statsClient.getStats(
+                earliestCreation,
+                LocalDateTime.now(),
+                uris,
+                true // Уникальные просмотры
+            );
+            if (stats != null) {
+                for (ViewStatsDto stat : stats) {
+                    try {
+                        Long eventId = Long.parseLong(stat.getUri().substring("/events/".length()));
+                        viewsMap.put(eventId, stat.getHits());
+                    } catch (NumberFormatException | IndexOutOfBoundsException e) {
+                        log.warn("Could not parse eventId from URI {} from stats service", stat.getUri());
+                    }
+                }
+            }
+        } catch (Exception e) {
+            log.error("Failed to retrieve views for multiple events. Error: {}", e.getMessage());
+        }
+        return viewsMap;
+    }
+
+    private Map<Long, Long> getConfirmedRequestsForEvents(List<Event> events) {
+        if (events == null || events.isEmpty()) {
+            return Collections.emptyMap();
+        }
+        Set<Long> eventIds = events.stream().map(Event::getId).collect(Collectors.toSet());
+        if (eventIds.isEmpty()) return Collections.emptyMap(); // На всякий случай
+
+        List<RequestRepository.ConfirmedRequestCountProjection> counts =
+            requestRepository.countConfirmedRequestsForEventIds(eventIds);
+
+        return counts.stream()
+            .collect(Collectors.toMap(
+                RequestRepository.ConfirmedRequestCountProjection::getEventId,
+                RequestRepository.ConfirmedRequestCountProjection::getRequestCount
+            ));
     }
 
     @Override
     @Transactional(readOnly = true)
     public EventFullDto getEventByIdPublic(Long eventId, String ipAddress) {
-        log.debug("Public: Fetching event id={}", eventId);
+        log.info("Public: Fetching event id={} from IP={}", eventId, ipAddress);
 
-        Event event = eventRepository.findById(eventId)
-                .orElseThrow(() -> new EntityNotFoundException("Event with id=" + eventId + " not found."));
+        Event event = eventRepository.findByIdAndState(eventId, EventState.PUBLISHED)
+            .orElseThrow(() -> new EntityNotFoundException(
+                String.format("Event with id=%d not found or is not published.", eventId)));
 
-        if (event.getState() != EventState.PUBLISHED) {
-            throw new EntityNotFoundException("Event with id=" + eventId + " is not published.");
+        long views = 0L;
+        try {
+            String eventUri = "/events/" + event.getId();
+            List<ViewStatsDto> stats = statsClient.getStats(
+                LocalDateTime.of(1970, 1, 1, 0, 0, 0), // Очень ранняя дата
+                LocalDateTime.now(),
+                List.of(eventUri),
+                true // Уникальные просмотры
+            );
+
+            if (stats != null && !stats.isEmpty()) {
+                Optional<ViewStatsDto> eventStat = stats.stream()
+                    .filter(s -> eventUri.equals(s.getUri()))
+                    .findFirst();
+                if (eventStat.isPresent()) {
+                    views = eventStat.get().getHits();
+                }
+            }
+            log.debug("Public: Views for event id={}: {}", eventId, views);
+        } catch (Exception e) {
+            log.error("Public: Failed to retrieve views for event id={}. Error: {}", eventId, e.getMessage());
         }
 
-        // TODO: Реализовать логику учета просмотров через ipAddress (StatsClient)
-        EventFullDto result = eventMapper.toEventFullDto(event);
-        log.debug("Public: Found event: {}", result);
-        return result;
+        long confirmedRequestsCount = requestRepository.countByEventIdAndStatus(eventId, RequestStatus.CONFIRMED);
+        log.debug("Public: Confirmed requests for event id={}: {}", eventId, confirmedRequestsCount);
+
+        EventFullDto resultDto = eventMapper.toEventFullDto(event);
+        resultDto.setViews(views);
+        resultDto.setConfirmedRequests(confirmedRequestsCount);
+
+        log.info("Public: Found event id={} with title='{}', views={}, confirmedRequests={}",
+            eventId, resultDto.getTitle(), resultDto.getViews(), resultDto.getConfirmedRequests());
+        return resultDto;
     }
 
     @Override
@@ -346,6 +456,10 @@ public class EventServiceImpl implements EventService {
     @Transactional(readOnly = true)
     public EventFullDto getEventPrivate(Long userId, Long eventId) {
         log.debug("Fetching event id: {} for user id: {}", eventId, userId);
+
+        if (!userRepository.existsById(userId)) {
+            throw new EntityNotFoundException("User with id=" + userId + " not found.");
+        }
 
         Event event = eventRepository.findByIdAndInitiatorId(eventId, userId)
                 .orElseThrow(() -> new EntityNotFoundException(

--- a/main-service/src/main/java/ru/practicum/explorewithme/main/service/EventServiceImpl.java
+++ b/main-service/src/main/java/ru/practicum/explorewithme/main/service/EventServiceImpl.java
@@ -243,9 +243,7 @@ public class EventServiceImpl implements EventService {
         List<EventFullDto> result = eventMapper.toEventFullDtoList(eventPage.getContent());
 
         Map<Long, Long> viewsData = getViewsForEvents(eventPage.getContent());
-        result.forEach(dto -> {
-            dto.setViews(viewsData.get(dto.getId()));
-        });
+        result.forEach(dto -> dto.setViews(viewsData.get(dto.getId())));
 
         log.debug("Admin search found {} events on page {}/{}", result.size(), pageable.getPageNumber(), eventPage.getTotalPages());
         return result;

--- a/main-service/src/main/java/ru/practicum/explorewithme/main/service/EventServiceImpl.java
+++ b/main-service/src/main/java/ru/practicum/explorewithme/main/service/EventServiceImpl.java
@@ -69,7 +69,7 @@ public class EventServiceImpl implements EventService {
         Boolean paid = params.getPaid();
         LocalDateTime rangeStart = params.getRangeStart();
         LocalDateTime rangeEnd = params.getRangeEnd();
-        boolean onlyAvailable = params.isOnlyAvailable(); // У вас был isOnlyAvailable()
+        boolean onlyAvailable = params.isOnlyAvailable();
         String sort = params.getSort();
 
         if (rangeStart != null && rangeEnd != null && rangeStart.isAfter(rangeEnd)) {

--- a/main-service/src/main/java/ru/practicum/explorewithme/main/service/EventServiceImpl.java
+++ b/main-service/src/main/java/ru/practicum/explorewithme/main/service/EventServiceImpl.java
@@ -11,7 +11,6 @@ import java.util.List;
 
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -134,7 +133,7 @@ public class EventServiceImpl implements EventService {
         if (onlyAvailable) {
             eventDtos = eventDtos.stream()
                 .filter(dto -> {
-                    Event event = eventMapById.get(dto.getId()); // Быстрый доступ
+                    Event event = eventMapById.get(dto.getId());
                     if (event == null) return false;
                     return event.getParticipantLimit() == 0 || dto.getConfirmedRequests() < event.getParticipantLimit();
                 })

--- a/main-service/src/main/java/ru/practicum/explorewithme/main/service/params/PublicEventSearchParams.java
+++ b/main-service/src/main/java/ru/practicum/explorewithme/main/service/params/PublicEventSearchParams.java
@@ -1,6 +1,7 @@
 package ru.practicum.explorewithme.main.service.params;
 
 import lombok.Builder;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
@@ -8,6 +9,7 @@ import java.util.List;
 
 @Getter
 @Builder
+@EqualsAndHashCode
 public class PublicEventSearchParams {
     private final String text;
     private final List<Long> categories;

--- a/main-service/src/main/resources/application-local.yaml
+++ b/main-service/src/main/resources/application-local.yaml
@@ -6,3 +6,7 @@ spring:
     url: jdbc:postgresql://localhost:5432/ewm_main_db
     username: ewm_user
     password: ewm_password
+logging:
+  level:
+    root: INFO
+    ru.practicum.explorewithme.main: DEBUG

--- a/main-service/src/test/java/ru/practicum/explorewithme/main/aspect/StatsHitAspectTest.java
+++ b/main-service/src/test/java/ru/practicum/explorewithme/main/aspect/StatsHitAspectTest.java
@@ -1,0 +1,115 @@
+package ru.practicum.explorewithme.main.aspect;
+
+import org.aspectj.lang.JoinPoint;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+import ru.practicum.explorewithme.stats.client.StatsClient;
+import ru.practicum.explorewithme.stats.dto.EndpointHitDto;
+
+import java.time.LocalDateTime;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("Тесты для StatsHitAspect")
+class StatsHitAspectTest {
+
+    @Mock
+    private StatsClient statsClient;
+
+    @Mock
+    private JoinPoint joinPoint;
+
+    @Mock
+    private org.aspectj.lang.Signature signature;
+
+    @InjectMocks
+    private StatsHitAspect statsHitAspect;
+
+    private MockHttpServletRequest mockRequest;
+
+    @Captor
+    private ArgumentCaptor<EndpointHitDto> endpointHitDtoCaptor;
+
+    private final String testAppName = "test-app-for-aspect";
+
+    @BeforeEach
+    void setUp() {
+        try {
+            java.lang.reflect.Field appNameField = StatsHitAspect.class.getDeclaredField("appName");
+            appNameField.setAccessible(true);
+            appNameField.set(statsHitAspect, testAppName);
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            throw new RuntimeException("Failed to set appName for testing", e);
+        }
+
+        mockRequest = new MockHttpServletRequest();
+        RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(mockRequest));
+    }
+
+    @AfterEach
+    void tearDown() {
+        RequestContextHolder.resetRequestAttributes();
+    }
+
+    @Test
+    @DisplayName("logHit должен отправлять EndpointHitDto в StatsClient с корректными данными")
+    void logHit_whenRequestAvailable_shouldSendHitToStatsClient() {
+        String testUri = "/test/uri";
+        String testIp = "123.123.123.123";
+        mockRequest.setRequestURI(testUri);
+        mockRequest.setRemoteAddr(testIp);
+
+        statsHitAspect.logHit(joinPoint);
+
+        verify(statsClient, times(1)).saveHit(endpointHitDtoCaptor.capture());
+        EndpointHitDto capturedDto = endpointHitDtoCaptor.getValue();
+
+        assertNotNull(capturedDto);
+        assertEquals(testAppName, capturedDto.getApp());
+        assertEquals(testUri, capturedDto.getUri());
+        assertEquals(testIp, capturedDto.getIp());
+        assertNotNull(capturedDto.getTimestamp());
+        assertTrue(capturedDto.getTimestamp().isAfter(LocalDateTime.now().minusSeconds(5)));
+        assertTrue(capturedDto.getTimestamp().isBefore(LocalDateTime.now().plusSeconds(5)));
+    }
+
+    @Test
+    @DisplayName("logHit не должен вызывать StatsClient, если HttpServletRequest недоступен")
+    void logHit_whenRequestNotAvailable_shouldNotCallStatsClientAndLogWarning() {
+        when(joinPoint.getSignature()).thenReturn(signature);
+        when(signature.toShortString()).thenReturn("testMethod()");
+        RequestContextHolder.resetRequestAttributes();
+
+        statsHitAspect.logHit(joinPoint);
+
+        verifyNoInteractions(statsClient);
+    }
+
+    @Test
+    @DisplayName("logHit должен обрабатывать исключение от StatsClient и не пробрасывать его дальше")
+    void logHit_whenStatsClientThrowsException_shouldCatchAndLogError() {
+        String testUri = "/test/uri";
+        String testIp = "123.123.123.123";
+        mockRequest.setRequestURI(testUri);
+        mockRequest.setRemoteAddr(testIp);
+
+        doThrow(new RuntimeException("Stats service unavailable")).when(statsClient).saveHit(any(EndpointHitDto.class));
+
+        assertDoesNotThrow(() -> statsHitAspect.logHit(joinPoint));
+
+        verify(statsClient, times(1)).saveHit(any(EndpointHitDto.class));
+    }
+}

--- a/main-service/src/test/java/ru/practicum/explorewithme/main/controller/pub/PublicEventControllerTest.java
+++ b/main-service/src/test/java/ru/practicum/explorewithme/main/controller/pub/PublicEventControllerTest.java
@@ -1,0 +1,379 @@
+package ru.practicum.explorewithme.main.controller.pub;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Arrays;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.EnableAspectJAutoProxy;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import ru.practicum.explorewithme.main.aspect.StatsHitAspect;
+import ru.practicum.explorewithme.main.dto.EventFullDto;
+import ru.practicum.explorewithme.main.dto.EventShortDto;
+import ru.practicum.explorewithme.main.model.EventState;
+import ru.practicum.explorewithme.main.service.EventService;
+import ru.practicum.explorewithme.main.service.params.PublicEventSearchParams;
+import ru.practicum.explorewithme.stats.client.StatsClient;
+import ru.practicum.explorewithme.stats.dto.EndpointHitDto;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Collections;
+import java.util.List;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static ru.practicum.explorewithme.common.constants.DateTimeConstants.DATE_TIME_FORMATTER;
+
+
+@WebMvcTest(PublicEventController.class)
+@Import({StatsHitAspect.class})
+@EnableAspectJAutoProxy
+@TestPropertySource(properties = {"spring.application.name=test-main-service-for-aspect"})
+@DisplayName("Тесты для PublicEventController и срабатывания StatsHitAspect")
+class PublicEventControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private EventService eventService;
+
+    @MockitoBean
+    private StatsClient statsClient;
+
+    @Value("${spring.application.name}")
+    private String configuredAppName;
+
+    @Captor
+    private ArgumentCaptor<EndpointHitDto> hitDtoCaptor;
+
+    private final DateTimeFormatter formatter = DATE_TIME_FORMATTER;
+    private final String testIpAddress = "192.168.0.1";
+
+
+    @BeforeEach
+    void setUp() {
+    }
+
+    @Nested
+    @DisplayName("GET /events")
+    class EventsEndpointTests {
+
+        @Test
+        @DisplayName("должен успешно возвращать список событий и отправлять хит в статистику")
+        void shouldReturnEventsAndLogHit() throws Exception {
+            EventShortDto event1 = EventShortDto.builder().id(1L).title("Event Alpha").build();
+            List<EventShortDto> mockEvents = List.of(event1);
+
+            when(eventService.getEventsPublic(any(PublicEventSearchParams.class), anyInt(), anyInt(), eq(testIpAddress)))
+                .thenReturn(mockEvents);
+
+            mockMvc.perform(get("/events")
+                    .param("text", "search text")
+                    .param("from", "0")
+                    .param("size", "10")
+                    .header("X-Real-IP", testIpAddress)
+                    .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(1)))
+                .andExpect(jsonPath("$[0].title", is("Event Alpha")));
+
+            PublicEventSearchParams expectedSearchParams = PublicEventSearchParams.builder()
+                .text("search text")
+                .categories(null)
+                .paid(null)
+                .rangeStart(null)
+                .rangeEnd(null)
+                .onlyAvailable(false)
+                .sort("EVENT_DATE")
+                .build();
+            verify(eventService).getEventsPublic(eq(expectedSearchParams), eq(0), eq(10), eq(testIpAddress));
+
+            verify(statsClient, times(1)).saveHit(hitDtoCaptor.capture());
+            EndpointHitDto capturedHit = hitDtoCaptor.getValue();
+            assertEquals(configuredAppName, capturedHit.getApp());
+            assertEquals("/events", capturedHit.getUri());
+            assertEquals(testIpAddress, capturedHit.getIp());
+            assertNotNull(capturedHit.getTimestamp());
+        }
+
+        @Test
+        @DisplayName("должен отправлять хит даже если сервис событий вернул пустой список")
+        void whenServiceReturnsEmpty_shouldStillLogHit() throws Exception {
+            when(eventService.getEventsPublic(any(PublicEventSearchParams.class), anyInt(), anyInt(), any()))
+                .thenReturn(Collections.emptyList());
+
+            mockMvc.perform(get("/events")
+                    .header("X-Real-IP", testIpAddress)
+                    .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(0)));
+
+            verify(statsClient, times(1)).saveHit(any(EndpointHitDto.class));
+        }
+
+        @Test
+        @DisplayName("должен использовать IP из заголовка X-Real-IP, если он есть")
+        void withXRealIpHeader_shouldUseHeaderIpForHit() throws Exception {
+            when(eventService.getEventsPublic(any(), anyInt(), anyInt(), eq("10.0.0.1"))).thenReturn(Collections.emptyList());
+
+            mockMvc.perform(get("/events")
+                    .header("X-Real-IP", "10.0.0.1")
+                    .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk());
+
+            verify(statsClient).saveHit(hitDtoCaptor.capture());
+            assertEquals("10.0.0.1", hitDtoCaptor.getValue().getIp());
+        }
+
+        @Test
+        @DisplayName("должен использовать IP из request.getRemoteAddr(), если заголовок X-Real-IP отсутствует")
+        void withoutXRealIpHeader_shouldUseRemoteAddrForHit() throws Exception {
+            String defaultMockIp = "127.0.0.1";
+            when(eventService.getEventsPublic(any(), anyInt(), anyInt(), eq(defaultMockIp)))
+                .thenReturn(Collections.emptyList());
+
+            mockMvc.perform(get("/events")
+                    .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk());
+
+            verify(statsClient).saveHit(hitDtoCaptor.capture());
+            assertEquals(defaultMockIp, hitDtoCaptor.getValue().getIp());
+        }
+
+        @Test
+        @DisplayName("должен корректно передавать все параметры фильтрации в сервис")
+        void withAllFilters_shouldPassAllParamsToService() throws Exception {
+            String text = "party";
+            List<Long> categories = Arrays.asList(1L, 2L);
+            Boolean paid = true;
+            LocalDateTime rangeStart = LocalDateTime.now().plusDays(1).withNano(0);
+            LocalDateTime rangeEnd = LocalDateTime.now().plusDays(2).withNano(0);
+            boolean onlyAvailable = true;
+            String sort = "VIEWS";
+            int from = 5;
+            int size = 15;
+            String ip = "10.0.0.2";
+
+            PublicEventSearchParams expectedSearchParams = PublicEventSearchParams.builder()
+                .text(text)
+                .categories(categories)
+                .paid(paid)
+                .rangeStart(rangeStart)
+                .rangeEnd(rangeEnd)
+                .onlyAvailable(onlyAvailable)
+                .sort(sort)
+                .build();
+
+            when(eventService.getEventsPublic(eq(expectedSearchParams), eq(from), eq(size), eq(ip)))
+                .thenReturn(Collections.emptyList());
+
+            mockMvc.perform(get("/events")
+                    .param("text", text)
+                    .param("categories", "1", "2")
+                    .param("paid", paid.toString())
+                    .param("rangeStart", rangeStart.format(formatter))
+                    .param("rangeEnd", rangeEnd.format(formatter))
+                    .param("onlyAvailable", String.valueOf(onlyAvailable))
+                    .param("sort", sort)
+                    .param("from", String.valueOf(from))
+                    .param("size", String.valueOf(size))
+                    .header("X-Real-IP", ip)
+                    .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk());
+
+            verify(eventService).getEventsPublic(eq(expectedSearchParams), eq(from), eq(size), eq(ip));
+            verify(statsClient).saveHit(any(EndpointHitDto.class));
+        }
+
+        @Test
+        @DisplayName("должен использовать значения по умолчанию для onlyAvailable и sort, если они не переданы")
+        void withDefaultSortAndAvailability_shouldUseDefaultValuesInServiceCall() throws Exception {
+            int from = 0;
+            int size = 10;
+            String defaultMockIp = "127.0.0.1";
+
+
+            PublicEventSearchParams expectedSearchParams = PublicEventSearchParams.builder()
+                .text(null)
+                .categories(null)
+                .paid(null)
+                .rangeStart(null)
+                .rangeEnd(null)
+                .onlyAvailable(false)
+                .sort("EVENT_DATE")
+                .build();
+
+            when(eventService.getEventsPublic(eq(expectedSearchParams), eq(from), eq(size), any()))
+                .thenReturn(Collections.emptyList());
+
+            mockMvc.perform(get("/events")
+                    .param("from", String.valueOf(from))
+                    .param("size", String.valueOf(size))
+                    .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk());
+
+            verify(eventService).getEventsPublic(eq(expectedSearchParams), eq(from), eq(size), any());
+            verify(statsClient).saveHit(any(EndpointHitDto.class));
+        }
+
+        @Test
+        @DisplayName("должен вернуть 400 Bad Request при невалидном значении 'from'")
+        void withInvalidFrom_shouldReturnBadRequest() throws Exception {
+            mockMvc.perform(get("/events")
+                    .param("from", "-1")
+                    .param("size", "10")
+                    .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest());
+            verifyNoInteractions(eventService);
+            verify(statsClient, never()).saveHit(any(EndpointHitDto.class));
+        }
+
+        @Test
+        @DisplayName("должен вернуть 400 Bad Request при невалидном значении 'size'")
+        void withInvalidSize_shouldReturnBadRequest() throws Exception {
+            mockMvc.perform(get("/events")
+                    .param("from", "0")
+                    .param("size", "0")
+                    .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest());
+            verifyNoInteractions(eventService);
+            verify(statsClient, never()).saveHit(any(EndpointHitDto.class));
+        }
+    }
+
+    @Nested
+    @DisplayName("GET /events/{eventId}")
+    class EventsByIdEndpointTests {
+
+        @Test
+        @DisplayName("должен успешно возвращать событие и отправлять хит в статистику")
+        void shouldReturnEventAndLogHit() throws Exception {
+            Long eventId = 1L;
+            EventFullDto mockEvent = EventFullDto.builder()
+                .id(eventId)
+                .title("Specific Event")
+                .eventDate(LocalDateTime.now().plusDays(1).withNano(0))
+                .build();
+
+            when(eventService.getEventByIdPublic(eq(eventId), eq(testIpAddress))).thenReturn(mockEvent);
+
+            mockMvc.perform(get("/events/{eventId}", eventId)
+                    .header("X-Real-IP", testIpAddress)
+                    .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id", is(eventId.intValue())))
+                .andExpect(jsonPath("$.title", is("Specific Event")));
+
+            verify(eventService).getEventByIdPublic(eq(eventId), eq(testIpAddress));
+
+            verify(statsClient, times(1)).saveHit(hitDtoCaptor.capture());
+            EndpointHitDto capturedHit = hitDtoCaptor.getValue();
+            assertEquals(configuredAppName, capturedHit.getApp());
+            assertEquals("/events/" + eventId, capturedHit.getUri());
+            assertEquals(testIpAddress, capturedHit.getIp());
+            assertNotNull(capturedHit.getTimestamp());
+        }
+
+        @Test
+        @DisplayName("должен отправлять хит даже если сервис событий выбросил NotFoundException")
+        void whenServiceThrowsNotFound_shouldStillLogHitAndReturn404() throws Exception {
+            Long eventId = 999L;
+            when(eventService.getEventByIdPublic(eq(eventId), any()))
+                .thenThrow(new ru.practicum.explorewithme.main.error.EntityNotFoundException("Event not found"));
+
+            mockMvc.perform(get("/events/{eventId}", eventId)
+                    .header("X-Real-IP", testIpAddress)
+                    .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isNotFound());
+
+            verify(statsClient, never()).saveHit(any(EndpointHitDto.class));
+        }
+
+        @Test
+        @DisplayName("должен вернуть 400 Bad Request при невалидном eventId в пути")
+        void withInvalidEventIdPath_shouldReturnBadRequest() throws Exception {
+            mockMvc.perform(get("/events/{eventId}", "notANumber")
+                    .header("X-Real-IP", testIpAddress)
+                    .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest());
+
+            verifyNoInteractions(eventService);
+            verify(statsClient, never()).saveHit(any(EndpointHitDto.class));
+        }
+
+        @Test
+        @DisplayName("должен проверять полные данные в EventFullDto при успешном ответе")
+        void whenEventFound_shouldReturnCorrectEventFullDtoFields() throws Exception {
+            Long eventId = 1L;
+            LocalDateTime eventDate = LocalDateTime.now().plusDays(1).withNano(0);
+            LocalDateTime createdOn = LocalDateTime.now().minusHours(5).withNano(0);
+            LocalDateTime publishedOn = LocalDateTime.now().minusHours(1).withNano(0);
+
+            EventFullDto mockEvent = EventFullDto.builder()
+                .id(eventId)
+                .title("Specific Event Title")
+                .annotation("Specific Annotation")
+                .description("Specific Description")
+                .eventDate(eventDate)
+                .createdOn(createdOn)
+                .publishedOn(publishedOn)
+                .paid(true)
+                .participantLimit(100)
+                .requestModeration(false)
+                .state(EventState.PUBLISHED)
+                .views(1000L)
+                .confirmedRequests(50L)
+                .build();
+
+            when(eventService.getEventByIdPublic(eq(eventId), eq(testIpAddress))).thenReturn(mockEvent);
+
+            mockMvc.perform(get("/events/{eventId}", eventId)
+                    .header("X-Real-IP", testIpAddress)
+                    .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id", is(eventId.intValue())))
+                .andExpect(jsonPath("$.title", is("Specific Event Title")))
+                .andExpect(jsonPath("$.annotation", is("Specific Annotation")))
+                .andExpect(jsonPath("$.description", is("Specific Description")))
+                .andExpect(jsonPath("$.eventDate", is(eventDate.format(formatter))))
+                .andExpect(jsonPath("$.createdOn", is(createdOn.format(formatter))))
+                .andExpect(jsonPath("$.publishedOn", is(publishedOn.format(formatter))))
+                .andExpect(jsonPath("$.paid", is(true)))
+                .andExpect(jsonPath("$.participantLimit", is(100)))
+                .andExpect(jsonPath("$.requestModeration", is(false)))
+                .andExpect(jsonPath("$.state", is("PUBLISHED")))
+                .andExpect(jsonPath("$.views", is(1000)))
+                .andExpect(jsonPath("$.confirmedRequests", is(50)));
+
+            verify(statsClient, times(1)).saveHit(any(EndpointHitDto.class));
+        }
+    }
+}

--- a/main-service/src/test/java/ru/practicum/explorewithme/main/controller/pub/PublicEventControllerTest.java
+++ b/main-service/src/test/java/ru/practicum/explorewithme/main/controller/pub/PublicEventControllerTest.java
@@ -92,7 +92,7 @@ class PublicEventControllerTest {
             EventShortDto event1 = EventShortDto.builder().id(1L).title("Event Alpha").build();
             List<EventShortDto> mockEvents = List.of(event1);
 
-            when(eventService.getEventsPublic(any(PublicEventSearchParams.class), anyInt(), anyInt(), eq(testIpAddress)))
+            when(eventService.getEventsPublic(any(PublicEventSearchParams.class), anyInt(), anyInt()))
                 .thenReturn(mockEvents);
 
             mockMvc.perform(get("/events")
@@ -114,7 +114,7 @@ class PublicEventControllerTest {
                 .onlyAvailable(false)
                 .sort("EVENT_DATE")
                 .build();
-            verify(eventService).getEventsPublic(eq(expectedSearchParams), eq(0), eq(10), eq(testIpAddress));
+            verify(eventService).getEventsPublic(eq(expectedSearchParams), eq(0), eq(10));
 
             verify(statsClient, times(1)).saveHit(hitDtoCaptor.capture());
             EndpointHitDto capturedHit = hitDtoCaptor.getValue();
@@ -127,7 +127,7 @@ class PublicEventControllerTest {
         @Test
         @DisplayName("должен отправлять хит даже если сервис событий вернул пустой список")
         void whenServiceReturnsEmpty_shouldStillLogHit() throws Exception {
-            when(eventService.getEventsPublic(any(PublicEventSearchParams.class), anyInt(), anyInt(), any()))
+            when(eventService.getEventsPublic(any(PublicEventSearchParams.class), anyInt(), anyInt()))
                 .thenReturn(Collections.emptyList());
 
             mockMvc.perform(get("/events")
@@ -142,7 +142,7 @@ class PublicEventControllerTest {
         @Test
         @DisplayName("должен использовать IP из заголовка X-Real-IP, если он есть")
         void withXRealIpHeader_shouldUseHeaderIpForHit() throws Exception {
-            when(eventService.getEventsPublic(any(), anyInt(), anyInt(), eq("10.0.0.1"))).thenReturn(Collections.emptyList());
+            when(eventService.getEventsPublic(any(), anyInt(), anyInt())).thenReturn(Collections.emptyList());
 
             mockMvc.perform(get("/events")
                     .header("X-Real-IP", "10.0.0.1")
@@ -157,7 +157,7 @@ class PublicEventControllerTest {
         @DisplayName("должен использовать IP из request.getRemoteAddr(), если заголовок X-Real-IP отсутствует")
         void withoutXRealIpHeader_shouldUseRemoteAddrForHit() throws Exception {
             String defaultMockIp = "127.0.0.1";
-            when(eventService.getEventsPublic(any(), anyInt(), anyInt(), eq(defaultMockIp)))
+            when(eventService.getEventsPublic(any(), anyInt(), anyInt()))
                 .thenReturn(Collections.emptyList());
 
             mockMvc.perform(get("/events")
@@ -192,7 +192,7 @@ class PublicEventControllerTest {
                 .sort(sort)
                 .build();
 
-            when(eventService.getEventsPublic(eq(expectedSearchParams), eq(from), eq(size), eq(ip)))
+            when(eventService.getEventsPublic(eq(expectedSearchParams), eq(from), eq(size)))
                 .thenReturn(Collections.emptyList());
 
             mockMvc.perform(get("/events")
@@ -209,7 +209,7 @@ class PublicEventControllerTest {
                     .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk());
 
-            verify(eventService).getEventsPublic(eq(expectedSearchParams), eq(from), eq(size), eq(ip));
+            verify(eventService).getEventsPublic(eq(expectedSearchParams), eq(from), eq(size));
             verify(statsClient).saveHit(any(EndpointHitDto.class));
         }
 
@@ -231,7 +231,7 @@ class PublicEventControllerTest {
                 .sort("EVENT_DATE")
                 .build();
 
-            when(eventService.getEventsPublic(eq(expectedSearchParams), eq(from), eq(size), any()))
+            when(eventService.getEventsPublic(eq(expectedSearchParams), eq(from), eq(size)))
                 .thenReturn(Collections.emptyList());
 
             mockMvc.perform(get("/events")
@@ -240,7 +240,7 @@ class PublicEventControllerTest {
                     .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk());
 
-            verify(eventService).getEventsPublic(eq(expectedSearchParams), eq(from), eq(size), any());
+            verify(eventService).getEventsPublic(eq(expectedSearchParams), eq(from), eq(size));
             verify(statsClient).saveHit(any(EndpointHitDto.class));
         }
 
@@ -283,7 +283,7 @@ class PublicEventControllerTest {
                 .eventDate(LocalDateTime.now().plusDays(1).withNano(0))
                 .build();
 
-            when(eventService.getEventByIdPublic(eq(eventId), eq(testIpAddress))).thenReturn(mockEvent);
+            when(eventService.getEventByIdPublic(eq(eventId))).thenReturn(mockEvent);
 
             mockMvc.perform(get("/events/{eventId}", eventId)
                     .header("X-Real-IP", testIpAddress)
@@ -292,7 +292,7 @@ class PublicEventControllerTest {
                 .andExpect(jsonPath("$.id", is(eventId.intValue())))
                 .andExpect(jsonPath("$.title", is("Specific Event")));
 
-            verify(eventService).getEventByIdPublic(eq(eventId), eq(testIpAddress));
+            verify(eventService).getEventByIdPublic(eq(eventId));
 
             verify(statsClient, times(1)).saveHit(hitDtoCaptor.capture());
             EndpointHitDto capturedHit = hitDtoCaptor.getValue();
@@ -306,7 +306,7 @@ class PublicEventControllerTest {
         @DisplayName("должен отправлять хит даже если сервис событий выбросил NotFoundException")
         void whenServiceThrowsNotFound_shouldStillLogHitAndReturn404() throws Exception {
             Long eventId = 999L;
-            when(eventService.getEventByIdPublic(eq(eventId), any()))
+            when(eventService.getEventByIdPublic(eq(eventId)))
                 .thenThrow(new ru.practicum.explorewithme.main.error.EntityNotFoundException("Event not found"));
 
             mockMvc.perform(get("/events/{eventId}", eventId)
@@ -353,7 +353,7 @@ class PublicEventControllerTest {
                 .confirmedRequests(50L)
                 .build();
 
-            when(eventService.getEventByIdPublic(eq(eventId), eq(testIpAddress))).thenReturn(mockEvent);
+            when(eventService.getEventByIdPublic(eq(eventId))).thenReturn(mockEvent);
 
             mockMvc.perform(get("/events/{eventId}", eventId)
                     .header("X-Real-IP", testIpAddress)

--- a/main-service/src/test/java/ru/practicum/explorewithme/main/mapper/EventMapperTest.java
+++ b/main-service/src/test/java/ru/practicum/explorewithme/main/mapper/EventMapperTest.java
@@ -12,8 +12,6 @@ import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;

--- a/main-service/src/test/java/ru/practicum/explorewithme/main/mapper/EventMapperTest.java
+++ b/main-service/src/test/java/ru/practicum/explorewithme/main/mapper/EventMapperTest.java
@@ -59,7 +59,7 @@ class EventMapperTest {
                 .requestModeration(true)
                 .state(EventState.PUBLISHED)
                 .title("Test Event Title")
-                .confirmedRequestsCount(42)
+                .confirmedRequestsCount(42L)
                 .build();
 
             EventFullDto dto = eventMapper.toEventFullDto(event);
@@ -202,7 +202,7 @@ class EventMapperTest {
                 .initiator(initiatorModel)
                 .paid(true)
                 .title("Short Event Title")
-                .confirmedRequestsCount(5)
+                .confirmedRequestsCount(5L)
                 .description("Full description not needed for short dto")
                 .state(EventState.PUBLISHED)
                 .build();
@@ -248,7 +248,7 @@ class EventMapperTest {
                 .initiator(null)
                 .paid(false)
                 .title("Event with Nulls")
-                .confirmedRequestsCount(33)
+                .confirmedRequestsCount(33L)
                 .build();
 
             EventShortDto dto = eventMapper.toEventShortDto(event);
@@ -271,9 +271,9 @@ class EventMapperTest {
             Category categoryModel = Category.builder().id(10L).name("Test Category").build();
 
             Event event1 = Event.builder().id(1L).title("Short Event 1").category(categoryModel).initiator(initiatorModel)
-                .eventDate(LocalDateTime.now()).annotation("A1").paid(true).confirmedRequestsCount(2).build();
+                .eventDate(LocalDateTime.now()).annotation("A1").paid(true).confirmedRequestsCount(2L).build();
             Event event2 = Event.builder().id(2L).title("Short Event 2").category(categoryModel).initiator(initiatorModel)
-                .eventDate(LocalDateTime.now()).annotation("A2").paid(false).confirmedRequestsCount(5).build();
+                .eventDate(LocalDateTime.now()).annotation("A2").paid(false).confirmedRequestsCount(5L).build();
             List<Event> events = Arrays.asList(event1, event2);
 
             List<EventShortDto> dtoList = eventMapper.toEventShortDtoList(events);

--- a/main-service/src/test/java/ru/practicum/explorewithme/main/mapper/EventMapperTest.java
+++ b/main-service/src/test/java/ru/practicum/explorewithme/main/mapper/EventMapperTest.java
@@ -18,13 +18,13 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import ru.practicum.explorewithme.main.dto.EventFullDto;
+import ru.practicum.explorewithme.main.dto.EventShortDto;
 import ru.practicum.explorewithme.main.model.Category;
 import ru.practicum.explorewithme.main.model.Event;
 import ru.practicum.explorewithme.main.model.EventState;
 import ru.practicum.explorewithme.main.model.Location;
 import ru.practicum.explorewithme.main.model.User;
 
-@ExtendWith(MockitoExtension.class)
 @DisplayName("Тесты для EventMapper")
 @ActiveProfiles("mapper_test")
 @SpringBootTest
@@ -59,6 +59,7 @@ class EventMapperTest {
                 .requestModeration(true)
                 .state(EventState.PUBLISHED)
                 .title("Test Event Title")
+                .confirmedRequestsCount(42)
                 .build();
 
             EventFullDto dto = eventMapper.toEventFullDto(event);
@@ -89,8 +90,9 @@ class EventMapperTest {
             assertEquals(locationModel.getLat(), dto.getLocation().getLat());
             assertEquals(locationModel.getLon(), dto.getLocation().getLon());
 
+            assertEquals(event.getConfirmedRequestsCount(), dto.getConfirmedRequests());
+
             // Не мапит просмотры и потдверждённые запросы.
-            assertNull(dto.getConfirmedRequests());
             assertNull(dto.getViews());
         }
 
@@ -177,6 +179,134 @@ class EventMapperTest {
         @DisplayName("должен возвращать пустой список, если на вход подан пустой список")
         void toEventFullDtoList_shouldHandleEmptyList() {
             List<EventFullDto> dtoList = eventMapper.toEventFullDtoList(Collections.emptyList());
+            assertNotNull(dtoList);
+            assertTrue(dtoList.isEmpty());
+        }
+    }
+
+    @Nested
+    @DisplayName("Метод toEventShortDto (маппинг одиночного события в EventShortDto)")
+    class ToEventShortDtoTests {
+
+        @Test
+        @DisplayName("Должен корректно маппить поля в EventShortDto")
+        void toEventShortDto_shouldMapFieldsCorrectly() {
+            User initiatorModel = User.builder().id(1L).name("Test User").build();
+            Category categoryModel = Category.builder().id(10L).name("Test Category").build();
+
+            Event event = Event.builder()
+                .id(1L)
+                .annotation("Short Test Annotation")
+                .category(categoryModel)
+                .eventDate(LocalDateTime.now().plusDays(5))
+                .initiator(initiatorModel)
+                .paid(true)
+                .title("Short Event Title")
+                .confirmedRequestsCount(5)
+                .description("Full description not needed for short dto")
+                .state(EventState.PUBLISHED)
+                .build();
+
+            EventShortDto dto = eventMapper.toEventShortDto(event);
+
+            assertNotNull(dto);
+            assertEquals(event.getId(), dto.getId());
+            assertEquals(event.getAnnotation(), dto.getAnnotation());
+            assertEquals(event.getEventDate(), dto.getEventDate());
+            assertEquals(event.isPaid(), dto.getPaid()); // Используем getPaid() для Boolean из EventShortDto
+            assertEquals(event.getTitle(), dto.getTitle());
+
+            assertNotNull(dto.getCategory());
+            assertEquals(categoryModel.getId(), dto.getCategory().getId());
+            assertEquals(categoryModel.getName(), dto.getCategory().getName());
+
+            assertNotNull(dto.getInitiator());
+            assertEquals(initiatorModel.getId(), dto.getInitiator().getId());
+            assertEquals(initiatorModel.getName(), dto.getInitiator().getName());
+
+            assertEquals(event.getConfirmedRequestsCount(), dto.getConfirmedRequests());
+
+            assertNull(dto.getViews(), "Views should be null as ignored by mapper and set by service");
+        }
+
+        @Test
+        @DisplayName("Должен возвращать null, если на вход подан null Event")
+        void toEventShortDto_shouldHandleNullEvent() {
+            EventShortDto dto = eventMapper.toEventShortDto(null);
+
+            assertNull(dto);
+        }
+
+        @Test
+        @DisplayName("Должен корректно обрабатывать null для вложенных Category и Initiator")
+        void toEventShortDto_shouldHandleNullNestedCategoryAndInitiator() {
+            Event event = Event.builder()
+                .id(1L)
+                .annotation("Annotation with nulls")
+                .category(null)
+                .eventDate(LocalDateTime.now().plusDays(5))
+                .initiator(null)
+                .paid(false)
+                .title("Event with Nulls")
+                .confirmedRequestsCount(33)
+                .build();
+
+            EventShortDto dto = eventMapper.toEventShortDto(event);
+
+            assertNotNull(dto);
+            assertNull(dto.getCategory(), "CategoryDto should be null if source category is null");
+            assertNull(dto.getInitiator(), "UserShortDto should be null if source initiator is null");
+            assertEquals(33L, dto.getConfirmedRequests()); // Проверяем confirmedRequests
+        }
+    }
+
+    @Nested
+    @DisplayName("Метод toEventShortDtoList (маппинг списка событий в список EventShortDto)")
+    class ToEventShortDtoListTests {
+
+        @Test
+        @DisplayName("Должен корректно маппить список событий в список EventShortDto")
+        void toEventShortDtoList_shouldMapListOfEvents() {
+            User initiatorModel = User.builder().id(1L).name("Test User").build();
+            Category categoryModel = Category.builder().id(10L).name("Test Category").build();
+
+            Event event1 = Event.builder().id(1L).title("Short Event 1").category(categoryModel).initiator(initiatorModel)
+                .eventDate(LocalDateTime.now()).annotation("A1").paid(true).confirmedRequestsCount(2).build();
+            Event event2 = Event.builder().id(2L).title("Short Event 2").category(categoryModel).initiator(initiatorModel)
+                .eventDate(LocalDateTime.now()).annotation("A2").paid(false).confirmedRequestsCount(5).build();
+            List<Event> events = Arrays.asList(event1, event2);
+
+            List<EventShortDto> dtoList = eventMapper.toEventShortDtoList(events);
+
+            assertNotNull(dtoList);
+            assertEquals(2, dtoList.size());
+
+            EventShortDto dto1 = dtoList.get(0);
+            assertEquals(event1.getTitle(), dto1.getTitle());
+            assertEquals(event1.getConfirmedRequestsCount(), dto1.getConfirmedRequests());
+            assertNotNull(dto1.getCategory());
+            assertEquals(categoryModel.getName(), dto1.getCategory().getName());
+
+            EventShortDto dto2 = dtoList.get(1);
+            assertEquals(event2.getTitle(), dto2.getTitle());
+            assertEquals(event2.getConfirmedRequestsCount(), dto2.getConfirmedRequests());
+            assertNotNull(dto2.getInitiator());
+            assertEquals(initiatorModel.getName(), dto2.getInitiator().getName());
+        }
+
+        @Test
+        @DisplayName("Должен возвращать null, если на вход подан null список")
+        void toEventShortDtoList_shouldHandleNullList() {
+            List<EventShortDto> dtoList = eventMapper.toEventShortDtoList(null);
+
+            assertNull(dtoList);
+        }
+
+        @Test
+        @DisplayName("Должен возвращать пустой список, если на вход подан пустой список")
+        void toEventShortDtoList_shouldHandleEmptyList() {
+            List<EventShortDto> dtoList = eventMapper.toEventShortDtoList(Collections.emptyList());
+
             assertNotNull(dtoList);
             assertTrue(dtoList.isEmpty());
         }

--- a/main-service/src/test/java/ru/practicum/explorewithme/main/mapper/EventMapperTest.java
+++ b/main-service/src/test/java/ru/practicum/explorewithme/main/mapper/EventMapperTest.java
@@ -89,8 +89,9 @@ class EventMapperTest {
             assertEquals(locationModel.getLat(), dto.getLocation().getLat());
             assertEquals(locationModel.getLon(), dto.getLocation().getLon());
 
-            assertEquals(0L, dto.getConfirmedRequests());
-            assertEquals(0L, dto.getViews());
+            // Не мапит просмотры и потдверждённые запросы.
+            assertNull(dto.getConfirmedRequests());
+            assertNull(dto.getViews());
         }
 
         @Test

--- a/main-service/src/test/java/ru/practicum/explorewithme/main/service/EventServiceIntegrationTest.java
+++ b/main-service/src/test/java/ru/practicum/explorewithme/main/service/EventServiceIntegrationTest.java
@@ -1,5 +1,6 @@
 package ru.practicum.explorewithme.main.service;
 
+import java.util.Collections;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -9,6 +10,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.transaction.annotation.Transactional;
 import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.Container;
@@ -23,14 +25,23 @@ import ru.practicum.explorewithme.main.error.EntityNotFoundException;
 import ru.practicum.explorewithme.main.model.*;
 import ru.practicum.explorewithme.main.repository.CategoryRepository;
 import ru.practicum.explorewithme.main.repository.EventRepository;
+import ru.practicum.explorewithme.main.repository.RequestRepository;
 import ru.practicum.explorewithme.main.repository.UserRepository;
 import ru.practicum.explorewithme.main.service.params.AdminEventSearchParams;
 
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
+import ru.practicum.explorewithme.main.service.params.PublicEventSearchParams;
+import ru.practicum.explorewithme.stats.client.StatsClient;
+import ru.practicum.explorewithme.stats.dto.ViewStatsDto;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
 
 @SpringBootTest
 @Testcontainers
@@ -61,26 +72,35 @@ class EventServiceIntegrationTest {
     @Autowired
     private CategoryRepository categoryRepository;
 
-    private User user1, user2;
+    @Autowired
+    private RequestRepository requestRepository;
+
+    @MockitoBean
+    private StatsClient statsClient;
+
+    private User user1, user2, user3;
     private Category category1, category2;
-    private Location location1;
+    private Location location1, location2;
     private LocalDateTime now;
 
     @BeforeEach
     void setUp() {
-        eventRepository.deleteAll();
-        categoryRepository.deleteAll();
-        userRepository.deleteAll();
+        requestRepository.deleteAllInBatch();
+        eventRepository.deleteAllInBatch();
+        categoryRepository.deleteAllInBatch();
+        userRepository.deleteAllInBatch();
 
         now = LocalDateTime.now().truncatedTo(ChronoUnit.SECONDS);
 
         user1 = userRepository.save(User.builder().name("User One").email("user1@events.com").build());
         user2 = userRepository.save(User.builder().name("User Two").email("user2@events.com").build());
+        user3 = userRepository.save(User.builder().name("User Three").email("user3@events.com").build());
 
         category1 = categoryRepository.save(Category.builder().name("Category A").build());
         category2 = categoryRepository.save(Category.builder().name("Category B").build());
 
         location1 = Location.builder().lat(10f).lon(10f).build();
+        location2 = Location.builder().lat(20f).lon(20f).build();
     }
 
     @Nested
@@ -274,7 +294,7 @@ class EventServiceIntegrationTest {
         @Test
         @DisplayName("Должен возвращать пустой список, если у пользователя нет событий")
         void getEventsByOwner_whenUserHasNoEvents_thenReturnsEmptyList() {
-            User userWithNoEvents = userRepository.save(User.builder().name("User Three").email("user3@events.com").build());
+            User userWithNoEvents = user3; // У user3 нет событий.
             List<EventShortDto> result = eventService.getEventsByOwner(userWithNoEvents.getId(), 0, 10);
             assertTrue(result.isEmpty());
         }
@@ -610,6 +630,269 @@ class EventServiceIntegrationTest {
             eventRepository.saveAndFlush(pendingEvent);
 
             assertThrows(EntityNotFoundException.class, () -> eventService.moderateEventByAdmin(pendingEvent.getId(), updateDtoWithBadCategory));
+        }
+    }
+
+    @Nested
+    @DisplayName("Метод getEventByIdPublic")
+    class GetEventByIdPublicIntegrationTests {
+        private Event publishedEvent;
+
+        @BeforeEach
+        void setUpPublicEvent() {
+            publishedEvent = Event.builder().title("Public Event Alpha").annotation("A_pub").description("D_pub")
+                .category(category1).initiator(user1).location(location1)
+                .eventDate(now.plusDays(1)).state(EventState.PENDING).createdOn(now.minusDays(10))
+                .participantLimit(10)
+                .build();
+            publishedEvent = eventRepository.save(publishedEvent);
+            publishedEvent.setState(EventState.PUBLISHED);
+            publishedEvent.setPublishedOn(now.minusDays(1));
+            publishedEvent = eventRepository.save(publishedEvent);
+
+            ParticipationRequest req1 = ParticipationRequest.builder().event(publishedEvent).requester(user2).status(RequestStatus.CONFIRMED).created(now).build();
+            ParticipationRequest req2 = ParticipationRequest.builder().event(publishedEvent).requester(user3).status(RequestStatus.CONFIRMED).created(now).build();
+            requestRepository.saveAll(List.of(req1, req2));
+        }
+
+        @Test
+        @DisplayName("Должен возвращать EventFullDto с просмотрами и подтвержденными запросами")
+        void getEventByIdPublic_whenEventExistsAndPublished_thenReturnsDtoWithViewsAndRequests() {
+            String eventUri = "/events/" + publishedEvent.getId();
+            ViewStatsDto viewStat = new ViewStatsDto("ewm-main-service", eventUri, 5L);
+            when(statsClient.getStats(any(LocalDateTime.class), any(LocalDateTime.class), eq(List.of(eventUri)), eq(true)))
+                .thenReturn(List.of(viewStat));
+
+            EventFullDto resultDto = eventService.getEventByIdPublic(publishedEvent.getId(), "127.0.0.1");
+
+            assertNotNull(resultDto);
+            assertEquals(publishedEvent.getId(), resultDto.getId());
+            assertEquals(publishedEvent.getTitle(), resultDto.getTitle());
+            assertEquals(5L, resultDto.getViews());
+            assertEquals(2L, resultDto.getConfirmedRequests());
+            assertEquals(EventState.PUBLISHED, resultDto.getState());
+        }
+
+        @Test
+        @DisplayName("Должен выбросить EntityNotFoundException, если событие не опубликовано")
+        void getEventByIdPublic_whenEventNotPublished_thenThrowsEntityNotFoundException() {
+            Event pendingEvent = Event.builder().title("Pending Event").annotation("A").description("D")
+                .category(category1).initiator(user1).location(location1)
+                .eventDate(now.plusDays(1)).state(EventState.PENDING).createdOn(now).build();
+            pendingEvent = eventRepository.save(pendingEvent);
+            Long pendingEventId = pendingEvent.getId();
+
+            assertThrows(EntityNotFoundException.class, () -> {
+                eventService.getEventByIdPublic(pendingEventId, "127.0.0.1");
+            });
+        }
+
+        @Test
+        @DisplayName("Просмотры должны быть 0, если сервис статистики вернул пустой список или ошибку")
+        void getEventByIdPublic_whenStatsServiceFailsOrReturnsEmpty_thenViewsAreZero() {
+            String eventUri = "/events/" + publishedEvent.getId();
+            when(statsClient.getStats(any(LocalDateTime.class), any(LocalDateTime.class), eq(List.of(eventUri)), eq(true)))
+                .thenReturn(Collections.emptyList());
+
+            EventFullDto resultDtoEmptyStats = eventService.getEventByIdPublic(publishedEvent.getId(), "127.0.0.1");
+            assertEquals(0L, resultDtoEmptyStats.getViews(), "Views should be 0 if stats service returns empty");
+
+            when(statsClient.getStats(any(LocalDateTime.class), any(LocalDateTime.class), eq(List.of(eventUri)), eq(true)))
+                .thenThrow(new RuntimeException("Stats service error"));
+
+            EventFullDto resultDtoErrorStats = eventService.getEventByIdPublic(publishedEvent.getId(), "127.0.0.1");
+            assertEquals(0L, resultDtoErrorStats.getViews(), "Views should be 0 if stats service throws error");
+            assertEquals(2L, resultDtoErrorStats.getConfirmedRequests());
+        }
+    }
+
+    @Nested
+    @DisplayName("Метод getEventsPublic")
+    class GetEventsPublicIntegrationTests {
+        private Event event1Pub, event2Pub, event3Pending, event4PastPub;
+
+        @BeforeEach
+        void setUpPublicEvents() {
+            event1Pub = Event.builder().title("Public Search Event Alpha")
+                .annotation("Alpha sports concert")
+                .description("Description for Public Search Event Alpha")
+                .category(category1).initiator(user1).location(location1).paid(false)
+                .eventDate(now.plusDays(5)).state(EventState.PUBLISHED)
+                .publishedOn(now.minusDays(1)).participantLimit(10).createdOn(now.minusDays(2))
+                .build(); // 5 подтверждённых запросов
+            event2Pub = Event.builder().title("Public Search Event Beta")
+                .annotation("Beta culture festival")
+                .description("Description for Public Search Event Beta")
+                .category(category2).initiator(user2).location(location2).paid(true)
+                .eventDate(now.plusDays(2)).state(EventState.PUBLISHED)
+                .publishedOn(now.minusDays(2)).participantLimit(3).createdOn(now.minusDays(3))
+                .build(); // 1 подтверждённый запрос
+            event3Pending = Event.builder().title("Public Search Event Gamma (Pending)")
+                .annotation("Gamma").description(
+                    "Description for Public Search Event Gamma (Pending)")
+                .category(category1).initiator(user1).location(location1).eventDate(now.plusDays(3))
+                .state(EventState.PENDING).createdOn(now.minusDays(1)).build();
+            event4PastPub = Event.builder().title("Past Public Event Delta")
+                .annotation("Delta retro")
+                .description("Description for Past Public Event Delta")
+                .category(category2).initiator(user2).location(location2).paid(false)
+                .eventDate(now.minusDays(1)).state(EventState.PUBLISHED)
+                .publishedOn(now.minusDays(2)).createdOn(now.minusDays(3)).build();
+
+            eventRepository.saveAll(List.of(event1Pub, event2Pub, event3Pending, event4PastPub));
+
+            requestRepository.save(ParticipationRequest.builder().event(event1Pub).requester(user2).status(RequestStatus.CONFIRMED).created(now).build());
+            requestRepository.save(ParticipationRequest.builder().event(event1Pub).requester(user3).status(RequestStatus.CONFIRMED).created(now).build());
+            for (int i = 0; i < 3; i++) {
+                User tempUser = userRepository.save(User.builder().name("Temp User " + i).email("temp"+i+"@mail.com").build());
+                requestRepository.save(ParticipationRequest.builder().event(event1Pub).requester(tempUser).status(RequestStatus.CONFIRMED).created(now).build());
+            }
+
+            requestRepository.save(ParticipationRequest.builder().event(event2Pub).requester(user1).status(RequestStatus.CONFIRMED).created(now).build());
+        }
+
+        @Test
+        @DisplayName("Должен возвращать только PUBLISHED события, если диапазон дат не указан (т.е. будущие)")
+        void getEventsPublic_noDateRange_shouldReturnFuturePublishedEvents() {
+            PublicEventSearchParams params = PublicEventSearchParams.builder().build();
+            when(statsClient.getStats(any(LocalDateTime.class), any(LocalDateTime.class), anyList(), anyBoolean()))
+                .thenReturn(Collections.emptyList());
+
+            List<EventShortDto> results = eventService.getEventsPublic(params, 0, 10, "127.0.0.1");
+
+            assertEquals(2, results.size(), "Should find 2 future published events (event1Pub, event2Pub)");
+            assertTrue(results.stream().anyMatch(e -> e.getId().equals(event1Pub.getId())));
+            assertTrue(results.stream().anyMatch(e -> e.getId().equals(event2Pub.getId())));
+        }
+
+        @Test
+        @DisplayName("Должен корректно фильтровать по тексту в аннотации или описании (регистронезависимо)")
+        void getEventsPublic_withTextFilter_shouldReturnMatchingEvents() {
+            PublicEventSearchParams params = PublicEventSearchParams.builder().text("alpha SpOrTs").build();
+            when(statsClient.getStats(any(), any(), anyList(), eq(true))).thenReturn(Collections.emptyList());
+
+            List<EventShortDto> results = eventService.getEventsPublic(params, 0, 10, "127.0.0.1");
+            assertEquals(1, results.size());
+            assertEquals(event1Pub.getId(), results.getFirst().getId());
+        }
+
+        @Test
+        @DisplayName("Должен корректно фильтровать по категориям")
+        void getEventsPublic_withCategoriesFilter_shouldReturnMatchingEvents() {
+            PublicEventSearchParams params = PublicEventSearchParams.builder().categories(List.of(category2.getId())).build();
+            when(statsClient.getStats(any(), any(), anyList(), eq(true))).thenReturn(Collections.emptyList());
+
+            List<EventShortDto> results = eventService.getEventsPublic(params, 0, 10, "127.0.0.1");
+            // event4PastPub не попадет в выборку, так как по умолчанию отбираются будущие события.
+            assertEquals(1, results.size(), "Expected 1 event in category B that is in the future and published");
+            assertEquals(event2Pub.getId(), results.getFirst().getId());
+        }
+
+        @Test
+        @DisplayName("Должен корректно фильтровать по платному участию (paid=true)")
+        void getEventsPublic_withPaidTrueFilter_shouldReturnPaidEvents() {
+            PublicEventSearchParams params = PublicEventSearchParams.builder().paid(true).build();
+            when(statsClient.getStats(any(), any(), anyList(), eq(true))).thenReturn(Collections.emptyList());
+
+            List<EventShortDto> results = eventService.getEventsPublic(params, 0, 10, "127.0.0.1");
+            assertEquals(1, results.size());
+            assertEquals(event2Pub.getId(), results.getFirst().getId());
+            assertTrue(results.getFirst().getPaid());
+        }
+
+        @Test
+        @DisplayName("Должен корректно фильтровать по диапазону дат, включая прошлое, если указан rangeStart")
+        void getEventsPublic_withDateRangeIncludingPast_shouldReturnMatchingEvents() {
+            PublicEventSearchParams params = PublicEventSearchParams.builder()
+                .rangeStart(now.minusDays(2))
+                .rangeEnd(now.plusDays(6))
+                .build();
+            when(statsClient.getStats(any(), any(), anyList(), eq(true))).thenReturn(Collections.emptyList());
+
+            List<EventShortDto> results = eventService.getEventsPublic(params, 0, 10, "127.0.0.1");
+
+            assertEquals(3, results.size(), "Should find event1Pub, event2Pub and event4PastPub");
+            assertTrue(results.stream().anyMatch(e -> e.getId().equals(event1Pub.getId())));
+            assertTrue(results.stream().anyMatch(e -> e.getId().equals(event4PastPub.getId())));
+        }
+
+        @Test
+        @DisplayName("Должен корректно фильтровать по onlyAvailable (только доступные)")
+        void getEventsPublic_withOnlyAvailableTrue_shouldReturnAvailableEvents() {
+            event4PastPub.setParticipantLimit(5);
+            requestRepository.save(ParticipationRequest.builder().event(event4PastPub).requester(user1).status(RequestStatus.CONFIRMED).created(now).build());
+            eventRepository.save(event4PastPub);
+
+
+            PublicEventSearchParams params = PublicEventSearchParams.builder()
+                .onlyAvailable(true)
+                .rangeStart(now.minusDays(5))
+                .build();
+            when(statsClient.getStats(any(), any(), anyList(), eq(true))).thenReturn(Collections.emptyList());
+
+            List<EventShortDto> results = eventService.getEventsPublic(params, 0, 10, "127.0.0.1");
+
+            assertEquals(3, results.size());
+            assertTrue(results.stream().anyMatch(e -> e.getId().equals(event1Pub.getId()) && e.getConfirmedRequests() == 5L));
+            assertTrue(results.stream().anyMatch(e -> e.getId().equals(event2Pub.getId()) && e.getConfirmedRequests() == 1L));
+            assertTrue(results.stream().anyMatch(e -> e.getId().equals(event4PastPub.getId()) && e.getConfirmedRequests() == 1L));
+
+            requestRepository.save(ParticipationRequest.builder().event(event2Pub).requester(user2).status(RequestStatus.CONFIRMED).created(now).build());
+            requestRepository.save(ParticipationRequest.builder().event(event2Pub).requester(user3).status(RequestStatus.CONFIRMED).created(now).build());
+
+            results = eventService.getEventsPublic(params, 0, 10, "127.0.0.1");
+            assertEquals(2, results.size(), "Event2Pub should now be unavailable");
+            assertFalse(results.stream().anyMatch(e -> e.getId().equals(event2Pub.getId())));
+        }
+
+        @Test
+        @DisplayName("Должен сортировать по просмотрам (VIEWS), если указано")
+        void getEventsPublic_withSortByViews_shouldSortByViewsDesc() {
+            String applicationName = "test-app-name";
+            String uri1 = "/events/" + event1Pub.getId();
+            String uri2 = "/events/" + event2Pub.getId();
+            PublicEventSearchParams params = PublicEventSearchParams.builder()
+                .sort("VIEWS")
+                .rangeStart(now.minusDays(5))
+                .build();
+
+            ViewStatsDto stat1 = new ViewStatsDto(applicationName, uri1, 100L);
+            ViewStatsDto stat2 = new ViewStatsDto(applicationName, uri2, 200L);
+            String uri4 = "/events/" + event4PastPub.getId();
+            ViewStatsDto stat4 = new ViewStatsDto(applicationName, uri4, 50L);
+
+            when(statsClient.getStats(any(LocalDateTime.class), any(LocalDateTime.class), anyList(), eq(true)))
+                .thenReturn(List.of(stat1, stat2, stat4));
+
+            List<EventShortDto> results = eventService.getEventsPublic(params, 0, 10, "127.0.0.1");
+
+            assertEquals(3, results.size());
+            assertEquals(event2Pub.getId(), results.get(0).getId(), "Event2 (200 views) should be first");
+            assertEquals(200L, results.get(0).getViews());
+            assertEquals(event1Pub.getId(), results.get(1).getId(), "Event1 (100 views) should be second");
+            assertEquals(100L, results.get(1).getViews());
+            assertEquals(event4PastPub.getId(), results.get(2).getId(), "Event4 (50 views) should be third");
+            assertEquals(50L, results.get(2).getViews());
+        }
+
+        @Test
+        @DisplayName("Должен сортировать по дате события (EVENT_DATE) по умолчанию или если указано")
+        void getEventsPublic_withSortByEventDate_shouldSortByEventDate() {
+            PublicEventSearchParams paramsDefaultSort = PublicEventSearchParams.builder().build();
+            PublicEventSearchParams paramsExplicitSort = PublicEventSearchParams.builder().sort("EVENT_DATE").build();
+
+            when(statsClient.getStats(any(), any(), anyList(), eq(true))).thenReturn(Collections.emptyList());
+
+            List<EventShortDto> resultsDefault = eventService.getEventsPublic(paramsDefaultSort, 0, 10, "127.0.0.1");
+            List<EventShortDto> resultsExplicit = eventService.getEventsPublic(paramsExplicitSort, 0, 10, "127.0.0.1");
+
+            assertEquals(2, resultsDefault.size());
+            assertEquals(event2Pub.getId(), resultsDefault.get(0).getId());
+            assertEquals(event1Pub.getId(), resultsDefault.get(1).getId());
+
+            assertEquals(2, resultsExplicit.size());
+            assertEquals(event2Pub.getId(), resultsExplicit.get(0).getId());
+            assertEquals(event1Pub.getId(), resultsExplicit.get(1).getId());
         }
     }
 }

--- a/main-service/src/test/java/ru/practicum/explorewithme/main/service/EventServiceIntegrationTest.java
+++ b/main-service/src/test/java/ru/practicum/explorewithme/main/service/EventServiceIntegrationTest.java
@@ -1,5 +1,6 @@
 package ru.practicum.explorewithme.main.service;
 
+import jakarta.persistence.EntityManager;
 import java.util.Collections;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
@@ -7,6 +8,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
@@ -59,6 +61,9 @@ class EventServiceIntegrationTest {
         registry.add("spring.datasource.password", postgresContainer::getPassword);
         registry.add("spring.jpa.hibernate.ddl-auto", () -> "create");
     }
+
+    @Autowired
+    private EntityManager entityManager;
 
     @Autowired
     private EventService eventService;
@@ -823,6 +828,8 @@ class EventServiceIntegrationTest {
             requestRepository.save(ParticipationRequest.builder().event(event4PastPub).requester(user1).status(RequestStatus.CONFIRMED).created(now).build());
             eventRepository.save(event4PastPub);
 
+            entityManager.flush();
+            entityManager.clear();
 
             PublicEventSearchParams params = PublicEventSearchParams.builder()
                 .onlyAvailable(true)
@@ -839,6 +846,9 @@ class EventServiceIntegrationTest {
 
             requestRepository.save(ParticipationRequest.builder().event(event2Pub).requester(user2).status(RequestStatus.CONFIRMED).created(now).build());
             requestRepository.save(ParticipationRequest.builder().event(event2Pub).requester(user3).status(RequestStatus.CONFIRMED).created(now).build());
+
+            entityManager.flush();
+            entityManager.clear();
 
             results = eventService.getEventsPublic(params, 0, 10);
             assertEquals(2, results.size(), "Event2Pub should now be unavailable");

--- a/main-service/src/test/java/ru/practicum/explorewithme/main/service/EventServiceIntegrationTest.java
+++ b/main-service/src/test/java/ru/practicum/explorewithme/main/service/EventServiceIntegrationTest.java
@@ -8,7 +8,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
@@ -687,9 +686,7 @@ class EventServiceIntegrationTest {
             pendingEvent = eventRepository.save(pendingEvent);
             Long pendingEventId = pendingEvent.getId();
 
-            assertThrows(EntityNotFoundException.class, () -> {
-                eventService.getEventByIdPublic(pendingEventId);
-            });
+            assertThrows(EntityNotFoundException.class, () -> eventService.getEventByIdPublic(pendingEventId));
         }
 
         @Test

--- a/main-service/src/test/java/ru/practicum/explorewithme/main/service/EventServiceIntegrationTest.java
+++ b/main-service/src/test/java/ru/practicum/explorewithme/main/service/EventServiceIntegrationTest.java
@@ -663,7 +663,7 @@ class EventServiceIntegrationTest {
             when(statsClient.getStats(any(LocalDateTime.class), any(LocalDateTime.class), eq(List.of(eventUri)), eq(true)))
                 .thenReturn(List.of(viewStat));
 
-            EventFullDto resultDto = eventService.getEventByIdPublic(publishedEvent.getId(), "127.0.0.1");
+            EventFullDto resultDto = eventService.getEventByIdPublic(publishedEvent.getId());
 
             assertNotNull(resultDto);
             assertEquals(publishedEvent.getId(), resultDto.getId());
@@ -683,7 +683,7 @@ class EventServiceIntegrationTest {
             Long pendingEventId = pendingEvent.getId();
 
             assertThrows(EntityNotFoundException.class, () -> {
-                eventService.getEventByIdPublic(pendingEventId, "127.0.0.1");
+                eventService.getEventByIdPublic(pendingEventId);
             });
         }
 
@@ -694,13 +694,13 @@ class EventServiceIntegrationTest {
             when(statsClient.getStats(any(LocalDateTime.class), any(LocalDateTime.class), eq(List.of(eventUri)), eq(true)))
                 .thenReturn(Collections.emptyList());
 
-            EventFullDto resultDtoEmptyStats = eventService.getEventByIdPublic(publishedEvent.getId(), "127.0.0.1");
+            EventFullDto resultDtoEmptyStats = eventService.getEventByIdPublic(publishedEvent.getId());
             assertEquals(0L, resultDtoEmptyStats.getViews(), "Views should be 0 if stats service returns empty");
 
             when(statsClient.getStats(any(LocalDateTime.class), any(LocalDateTime.class), eq(List.of(eventUri)), eq(true)))
                 .thenThrow(new RuntimeException("Stats service error"));
 
-            EventFullDto resultDtoErrorStats = eventService.getEventByIdPublic(publishedEvent.getId(), "127.0.0.1");
+            EventFullDto resultDtoErrorStats = eventService.getEventByIdPublic(publishedEvent.getId());
             assertEquals(0L, resultDtoErrorStats.getViews(), "Views should be 0 if stats service throws error");
             assertEquals(2L, resultDtoErrorStats.getConfirmedRequests());
         }
@@ -744,7 +744,7 @@ class EventServiceIntegrationTest {
             requestRepository.save(ParticipationRequest.builder().event(event1Pub).requester(user2).status(RequestStatus.CONFIRMED).created(now).build());
             requestRepository.save(ParticipationRequest.builder().event(event1Pub).requester(user3).status(RequestStatus.CONFIRMED).created(now).build());
             for (int i = 0; i < 3; i++) {
-                User tempUser = userRepository.save(User.builder().name("Temp User " + i).email("temp"+i+"@mail.com").build());
+                User tempUser = userRepository.save(User.builder().name("Temp User " + i).email("temp" + i + "@mail.com").build());
                 requestRepository.save(ParticipationRequest.builder().event(event1Pub).requester(tempUser).status(RequestStatus.CONFIRMED).created(now).build());
             }
 
@@ -758,7 +758,7 @@ class EventServiceIntegrationTest {
             when(statsClient.getStats(any(LocalDateTime.class), any(LocalDateTime.class), anyList(), anyBoolean()))
                 .thenReturn(Collections.emptyList());
 
-            List<EventShortDto> results = eventService.getEventsPublic(params, 0, 10, "127.0.0.1");
+            List<EventShortDto> results = eventService.getEventsPublic(params, 0, 10);
 
             assertEquals(2, results.size(), "Should find 2 future published events (event1Pub, event2Pub)");
             assertTrue(results.stream().anyMatch(e -> e.getId().equals(event1Pub.getId())));
@@ -771,7 +771,7 @@ class EventServiceIntegrationTest {
             PublicEventSearchParams params = PublicEventSearchParams.builder().text("alpha SpOrTs").build();
             when(statsClient.getStats(any(), any(), anyList(), eq(true))).thenReturn(Collections.emptyList());
 
-            List<EventShortDto> results = eventService.getEventsPublic(params, 0, 10, "127.0.0.1");
+            List<EventShortDto> results = eventService.getEventsPublic(params, 0, 10);
             assertEquals(1, results.size());
             assertEquals(event1Pub.getId(), results.getFirst().getId());
         }
@@ -782,7 +782,7 @@ class EventServiceIntegrationTest {
             PublicEventSearchParams params = PublicEventSearchParams.builder().categories(List.of(category2.getId())).build();
             when(statsClient.getStats(any(), any(), anyList(), eq(true))).thenReturn(Collections.emptyList());
 
-            List<EventShortDto> results = eventService.getEventsPublic(params, 0, 10, "127.0.0.1");
+            List<EventShortDto> results = eventService.getEventsPublic(params, 0, 10);
             // event4PastPub не попадет в выборку, так как по умолчанию отбираются будущие события.
             assertEquals(1, results.size(), "Expected 1 event in category B that is in the future and published");
             assertEquals(event2Pub.getId(), results.getFirst().getId());
@@ -794,7 +794,7 @@ class EventServiceIntegrationTest {
             PublicEventSearchParams params = PublicEventSearchParams.builder().paid(true).build();
             when(statsClient.getStats(any(), any(), anyList(), eq(true))).thenReturn(Collections.emptyList());
 
-            List<EventShortDto> results = eventService.getEventsPublic(params, 0, 10, "127.0.0.1");
+            List<EventShortDto> results = eventService.getEventsPublic(params, 0, 10);
             assertEquals(1, results.size());
             assertEquals(event2Pub.getId(), results.getFirst().getId());
             assertTrue(results.getFirst().getPaid());
@@ -809,7 +809,7 @@ class EventServiceIntegrationTest {
                 .build();
             when(statsClient.getStats(any(), any(), anyList(), eq(true))).thenReturn(Collections.emptyList());
 
-            List<EventShortDto> results = eventService.getEventsPublic(params, 0, 10, "127.0.0.1");
+            List<EventShortDto> results = eventService.getEventsPublic(params, 0, 10);
 
             assertEquals(3, results.size(), "Should find event1Pub, event2Pub and event4PastPub");
             assertTrue(results.stream().anyMatch(e -> e.getId().equals(event1Pub.getId())));
@@ -830,7 +830,7 @@ class EventServiceIntegrationTest {
                 .build();
             when(statsClient.getStats(any(), any(), anyList(), eq(true))).thenReturn(Collections.emptyList());
 
-            List<EventShortDto> results = eventService.getEventsPublic(params, 0, 10, "127.0.0.1");
+            List<EventShortDto> results = eventService.getEventsPublic(params, 0, 10);
 
             assertEquals(3, results.size());
             assertTrue(results.stream().anyMatch(e -> e.getId().equals(event1Pub.getId()) && e.getConfirmedRequests() == 5L));
@@ -840,7 +840,7 @@ class EventServiceIntegrationTest {
             requestRepository.save(ParticipationRequest.builder().event(event2Pub).requester(user2).status(RequestStatus.CONFIRMED).created(now).build());
             requestRepository.save(ParticipationRequest.builder().event(event2Pub).requester(user3).status(RequestStatus.CONFIRMED).created(now).build());
 
-            results = eventService.getEventsPublic(params, 0, 10, "127.0.0.1");
+            results = eventService.getEventsPublic(params, 0, 10);
             assertEquals(2, results.size(), "Event2Pub should now be unavailable");
             assertFalse(results.stream().anyMatch(e -> e.getId().equals(event2Pub.getId())));
         }
@@ -864,7 +864,7 @@ class EventServiceIntegrationTest {
             when(statsClient.getStats(any(LocalDateTime.class), any(LocalDateTime.class), anyList(), eq(true)))
                 .thenReturn(List.of(stat1, stat2, stat4));
 
-            List<EventShortDto> results = eventService.getEventsPublic(params, 0, 10, "127.0.0.1");
+            List<EventShortDto> results = eventService.getEventsPublic(params, 0, 10);
 
             assertEquals(3, results.size());
             assertEquals(event2Pub.getId(), results.get(0).getId(), "Event2 (200 views) should be first");
@@ -883,8 +883,8 @@ class EventServiceIntegrationTest {
 
             when(statsClient.getStats(any(), any(), anyList(), eq(true))).thenReturn(Collections.emptyList());
 
-            List<EventShortDto> resultsDefault = eventService.getEventsPublic(paramsDefaultSort, 0, 10, "127.0.0.1");
-            List<EventShortDto> resultsExplicit = eventService.getEventsPublic(paramsExplicitSort, 0, 10, "127.0.0.1");
+            List<EventShortDto> resultsDefault = eventService.getEventsPublic(paramsDefaultSort, 0, 10);
+            List<EventShortDto> resultsExplicit = eventService.getEventsPublic(paramsExplicitSort, 0, 10);
 
             assertEquals(2, resultsDefault.size());
             assertEquals(event2Pub.getId(), resultsDefault.get(0).getId());

--- a/stats-service/stats-client/src/main/java/ru/practicum/explorewithme/stats/client/StatsClientImpl.java
+++ b/stats-service/stats-client/src/main/java/ru/practicum/explorewithme/stats/client/StatsClientImpl.java
@@ -5,6 +5,7 @@ import static ru.practicum.explorewithme.common.constants.DateTimeConstants.DATE
 import java.time.LocalDateTime;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpStatusCode;
@@ -21,6 +22,7 @@ public class StatsClientImpl implements StatsClient {
 
     private final RestClient restClient;
 
+    @Autowired
     public StatsClientImpl(@Value("${stats-server.url}") String statsServerUrl) {
         this.restClient = RestClient.builder()
                 .baseUrl(statsServerUrl)

--- a/stats-service/stats-client/src/main/java/ru/practicum/explorewithme/stats/client/config/StatsClientModuleConfiguration.java
+++ b/stats-service/stats-client/src/main/java/ru/practicum/explorewithme/stats/client/config/StatsClientModuleConfiguration.java
@@ -1,0 +1,9 @@
+package ru.practicum.explorewithme.stats.client.config;
+
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ComponentScan("ru.practicum.explorewithme.stats.client")
+public class StatsClientModuleConfiguration {
+}


### PR DESCRIPTION
## Описание

Данный Pull Request реализует публичные эндпоинты для работы с событиями (`GET /events` и `GET /events/{id}`) и интегрирует взаимодействие с сервисом статистики (`StatsClient`) для учета просмотров.

### Ключевые изменения:

1.  **Интеграция `StatsClient` (`CORE: Интеграция StatsClient`):**
    *   Настроен AOP аспект (`StatsHitAspect`) для автоматической отправки информации о запросах (хитах) к публичным эндпоинтам событий в сервис статистики.
    *   Обеспечена корректная конфигурация бина `StatsClient` в `main-service`.

2.  **Публичное API для событий:**
    *   **`GET /events/{id}` (`PUBLIC-EVENTS: Получение подробной информации об опубликованном событии`):**
        *   Реализован эндпоинт для получения полной информации об одном опубликованном событии.
        *   DTO ответа (`EventFullDto`) обогащается данными о количестве просмотров (через `StatsClient`) и количестве подтвержденных заявок на участие (через `RequestRepository`).
    *   **`GET /events` (`PUBLIC-EVENTS: Получение событий с фильтрацией`):**
        *   Реализован эндпоинт для получения списка опубликованных событий с поддержкой фильтрации по тексту, категориям, платному участию, диапазону дат и доступности (`onlyAvailable`).
        *   Реализована сортировка по дате события (`EVENT_DATE`) и по количеству просмотров (`VIEWS`).
        *   DTO ответа (`List<EventShortDto>`) обогащаются данными о просмотрах и подтвержденных заявках.
        *   Для получения данных о просмотрах и заявках для списка событий используются оптимизированные запросы для избежания проблемы N+1.

3.  **Улучшения сущности `Event`:**
    *   Поле `confirmedRequestsCount` теперь вычисляется с помощью аннотации `@Formula` для получения актуального количества подтвержденных заявок при загрузке события. Это решает потенциальные проблемы с консистентностью данных в многопоточных сценариях (например, в тестах).

4.  **Тестирование:**
    *   Добавлены/обновлены юнит-тесты для `EventServiceImpl`, `PublicEventController` и `StatsHitAspect`.
    *   Добавлены/обновлены интеграционные тесты (`@SpringBootTest` с Testcontainers) для `EventServiceImpl`, проверяющие корректность работы публичных эндпоинтов, включая фильтрацию, сортировку, получение данных из `StatsClient` (через мок) и `RequestRepository`.