### PR TITLE
устранение ошибки

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -202,6 +202,8 @@
 					<artifactId>maven-surefire-plugin</artifactId>
 					<version>3.5.3</version>
 					<configuration>
+						<forkCount>1</forkCount>
+						<reuseForks>false</reuseForks>
 						<systemPropertyVariables>
 							<spring.profiles.active>test</spring.profiles.active>
 						</systemPropertyVariables>


### PR DESCRIPTION
исправлено [ERROR] Surefire is going to kill self fork JVM. The exit has elapsed 30 seconds after System.exit(0)

forkCount указывает, сколько отдельных JVM-процессов будет создано для тестов. Значение 1 — запускать все тесты в одном отдельном процессе.
reuseForks=false говорит Maven не переиспользовать одни и те же JVM-процессы для разных наборов тестов, а стартовать (и завершать) каждый раз новый процесс.

Когда reuseForks=true (по умолчанию), Maven пытается запускать несколько тестовых классов подряд в одной и той же JVM. Если какой-то тест или библиотека (например Testcontainers или HikariCP) оставляют после себя не полностью завершённый поток, пул соединений, или какой-то другой ресурс — процесс не может чисто завершиться, возникают хвосты и залипания при выключении JVM.
Когда reuseForks=false, каждый раз для тестов создаётся новая JVM и она всегда гарантированно будет полностью завершена после теста, даже если где-то есть "зависшие" ресурсы, ведь весь процесс убивается целиком. Это устраняет ситуации, когда пул соединений или тестовый контейнер уже мёртв, а какой-то поток ещё жив или ждёт.
Особенно это актуально в интеграционных тестах с Testcontainers и Spring Boot, потому что там контейнеры/пулы/ресурсы могут быть созданы в разных потоках, а их завершение не всегда сразу срабатывает.

Таким образом, даже если где-то библиотека неправильно завершает соединения, ресурсы или потоки — следующий тест уже стартует в новом чистом процессе, и не унаследует "хвосты" предыдущих тестов. Благодаря этому исчезают ошибки, связанные с невозможностью корректно "убить" JVM или с закрытием соединений, которые уже были уничтожены вместе с контейнером БД.