### PR TITLE
COMMENTS-PRIVATE: Создание/обновление комментария пользователем #84 и #86

### DIFF
--- a/main-service/src/main/java/ru/practicum/explorewithme/main/controller/priv/PrivateCommentController.java
+++ b/main-service/src/main/java/ru/practicum/explorewithme/main/controller/priv/PrivateCommentController.java
@@ -37,7 +37,7 @@ public class PrivateCommentController {
 
     @PatchMapping("/{commentId}")
     @ResponseStatus(HttpStatus.OK)
-    public CommentDto updateComment (
+    public CommentDto updateComment(
             @PathVariable @Positive Long userId,
             @PathVariable @Positive Long commentId,
             @Valid @RequestBody UpdateCommentDto updateCommentDto) {

--- a/main-service/src/main/java/ru/practicum/explorewithme/main/controller/priv/PrivateCommentController.java
+++ b/main-service/src/main/java/ru/practicum/explorewithme/main/controller/priv/PrivateCommentController.java
@@ -10,6 +10,7 @@ import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import ru.practicum.explorewithme.main.dto.CommentDto;
 import ru.practicum.explorewithme.main.dto.NewCommentDto;
+import ru.practicum.explorewithme.main.dto.UpdateCommentDto;
 import ru.practicum.explorewithme.main.service.CommentService;
 
 @RestController
@@ -26,10 +27,24 @@ public class PrivateCommentController {
             @PathVariable @Positive Long userId,
             @RequestParam @Positive Long eventId,
             @Valid @RequestBody NewCommentDto newCommentDto) {
+
         log.info("Создание нового комментария {} зарегистрированным пользователем c id {} " +
                 "к событию с id {}", newCommentDto, userId, eventId);
+
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(commentService.addComment(userId, eventId, newCommentDto));
     }
 
+    @PatchMapping("/{commentId}")
+    @ResponseStatus(HttpStatus.OK)
+    public CommentDto updateComment (
+            @PathVariable @Positive Long userId,
+            @PathVariable @Positive Long commentId,
+            @Valid @RequestBody UpdateCommentDto updateCommentDto) {
+
+        log.info("Обновление комментария c id {} пользователем c id {}," +
+                " новый комментарий {}", commentId, userId, updateCommentDto);
+
+        return commentService.updateUserComment(userId, commentId, updateCommentDto);
+    }
 }

--- a/main-service/src/main/java/ru/practicum/explorewithme/main/controller/priv/PrivateCommentController.java
+++ b/main-service/src/main/java/ru/practicum/explorewithme/main/controller/priv/PrivateCommentController.java
@@ -1,0 +1,35 @@
+package ru.practicum.explorewithme.main.controller.priv;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Positive;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+import ru.practicum.explorewithme.main.dto.CommentDto;
+import ru.practicum.explorewithme.main.dto.NewCommentDto;
+import ru.practicum.explorewithme.main.service.CommentService;
+
+@RestController
+@RequestMapping("/users/{userId}/comments")
+@RequiredArgsConstructor
+@Validated
+@Slf4j
+public class PrivateCommentController {
+
+    private final CommentService commentService;
+
+    @PostMapping
+    public ResponseEntity<CommentDto> createComment(
+            @PathVariable @Positive Long userId,
+            @RequestParam @Positive Long eventId,
+            @Valid @RequestBody NewCommentDto newCommentDto) {
+        log.info("Создание нового комментария {} зарегистрированным пользователем c id {} " +
+                "к событию с id {}", newCommentDto, userId, eventId);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(commentService.addComment(userId, eventId, newCommentDto));
+    }
+
+}

--- a/main-service/src/main/java/ru/practicum/explorewithme/main/controller/priv/PrivateCommentController.java
+++ b/main-service/src/main/java/ru/practicum/explorewithme/main/controller/priv/PrivateCommentController.java
@@ -37,7 +37,7 @@ public class PrivateCommentController {
 
     @PatchMapping("/{commentId}")
     @ResponseStatus(HttpStatus.OK)
-    public CommentDto updateComment(
+    public ResponseEntity<CommentDto> updateComment(
             @PathVariable @Positive Long userId,
             @PathVariable @Positive Long commentId,
             @Valid @RequestBody UpdateCommentDto updateCommentDto) {
@@ -45,6 +45,6 @@ public class PrivateCommentController {
         log.info("Обновление комментария c id {} пользователем c id {}," +
                 " новый комментарий {}", commentId, userId, updateCommentDto);
 
-        return commentService.updateUserComment(userId, commentId, updateCommentDto);
+        return ResponseEntity.status(HttpStatus.OK).body(commentService.updateUserComment(userId, commentId, updateCommentDto));
     }
 }

--- a/main-service/src/main/java/ru/practicum/explorewithme/main/service/CommentService.java
+++ b/main-service/src/main/java/ru/practicum/explorewithme/main/service/CommentService.java
@@ -1,0 +1,9 @@
+package ru.practicum.explorewithme.main.service;
+
+import ru.practicum.explorewithme.main.dto.CommentDto;
+import ru.practicum.explorewithme.main.dto.NewCommentDto;
+
+public interface CommentService {
+
+    CommentDto addComment(Long userId, Long eventId, NewCommentDto newCommentDto);
+}

--- a/main-service/src/main/java/ru/practicum/explorewithme/main/service/CommentService.java
+++ b/main-service/src/main/java/ru/practicum/explorewithme/main/service/CommentService.java
@@ -2,8 +2,11 @@ package ru.practicum.explorewithme.main.service;
 
 import ru.practicum.explorewithme.main.dto.CommentDto;
 import ru.practicum.explorewithme.main.dto.NewCommentDto;
+import ru.practicum.explorewithme.main.dto.UpdateCommentDto;
 
 public interface CommentService {
 
     CommentDto addComment(Long userId, Long eventId, NewCommentDto newCommentDto);
+
+    CommentDto updateUserComment(Long userId, Long commentId, UpdateCommentDto updateCommentDto);
 }

--- a/main-service/src/main/java/ru/practicum/explorewithme/main/service/CommentServiceImpl.java
+++ b/main-service/src/main/java/ru/practicum/explorewithme/main/service/CommentServiceImpl.java
@@ -1,0 +1,59 @@
+package ru.practicum.explorewithme.main.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import ru.practicum.explorewithme.main.dto.CommentDto;
+import ru.practicum.explorewithme.main.dto.NewCommentDto;
+import ru.practicum.explorewithme.main.error.BusinessRuleViolationException;
+import ru.practicum.explorewithme.main.error.EntityNotFoundException;
+import ru.practicum.explorewithme.main.mapper.CommentMapper;
+import ru.practicum.explorewithme.main.model.Comment;
+import ru.practicum.explorewithme.main.model.Event;
+import ru.practicum.explorewithme.main.model.EventState;
+import ru.practicum.explorewithme.main.model.User;
+import ru.practicum.explorewithme.main.repository.CommentRepository;
+import ru.practicum.explorewithme.main.repository.EventRepository;
+import ru.practicum.explorewithme.main.repository.UserRepository;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class CommentServiceImpl implements CommentService {
+
+    UserRepository userRepository;
+    EventRepository eventRepository;
+    CommentMapper commentMapper;
+    CommentRepository commentRepository;
+
+    @Override
+    @Transactional
+    public CommentDto addComment(Long userId, Long eventId, NewCommentDto newCommentDto) {
+
+        Optional<User> user = userRepository.findById(userId);
+        if (user.isEmpty()) {
+            throw new EntityNotFoundException("Пользователь с id " + userId + " не найден");
+        }
+
+        Optional<Event> event = eventRepository.findById(eventId);
+        if (event.isEmpty()) {
+            throw new EntityNotFoundException("Событие с id " + eventId + " не найден");
+        }
+        if (!event.get().getState().equals(EventState.PUBLISHED)) {
+            throw new BusinessRuleViolationException("Событие еще не опубликовано");
+        }
+        if (!event.get().isCommentsEnabled()) {
+            throw new BusinessRuleViolationException("Комментарии запрещены");
+        }
+
+        Comment comment = commentMapper.toComment(newCommentDto);
+
+        comment.setAuthor(user.get());
+        comment.setEvent(event.get());
+
+        commentRepository.save(comment);
+
+        return commentMapper.toDto(comment);
+    }
+}

--- a/main-service/src/test/java/ru/practicum/explorewithme/main/controller/priv/PrivateCommentControllerTest.java
+++ b/main-service/src/test/java/ru/practicum/explorewithme/main/controller/priv/PrivateCommentControllerTest.java
@@ -1,0 +1,112 @@
+package ru.practicum.explorewithme.main.controller.priv;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import ru.practicum.explorewithme.main.dto.CommentDto;
+import ru.practicum.explorewithme.main.dto.NewCommentDto;
+import ru.practicum.explorewithme.main.dto.UserShortDto;
+import ru.practicum.explorewithme.main.service.CommentService;
+
+import java.time.LocalDateTime;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post; // <-- для post-запроса
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+
+@WebMvcTest(PrivateCommentController.class)
+public class PrivateCommentControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private CommentService commentService;
+
+    private ObjectMapper objectMapper;
+
+    private final Long userId = 1L;
+    private final Long eventId = 100L;
+
+    private NewCommentDto newCommentDto;
+    private CommentDto commentDto;
+
+    @BeforeEach
+    void setUp() {
+        objectMapper = new ObjectMapper();
+        objectMapper.findAndRegisterModules();
+
+        newCommentDto = NewCommentDto.builder()
+                .text("Test comment text")
+                .build();
+
+        UserShortDto author = UserShortDto.builder()
+                .id(2L)
+                .name("testUser")
+                .build();
+
+        commentDto = CommentDto.builder()
+                .id(10L)
+                .text(newCommentDto.getText())
+                .author(author)
+                .eventId(eventId)
+                .createdOn(LocalDateTime.now())
+                .updatedOn(LocalDateTime.now())
+                .isEdited(false)
+                .build();
+    }
+
+    @Test
+    void createComment_whenValidInput_thenReturnsCreatedComment() throws Exception {
+        when(commentService.addComment(eq(userId), eq(eventId), any(NewCommentDto.class)))
+                .thenReturn(commentDto);
+
+        mockMvc.perform(post("/users/{userId}/comments?eventId={eventId}", userId, eventId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(newCommentDto)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.id").value(commentDto.getId()))
+                .andExpect(jsonPath("$.text").value(commentDto.getText()))
+                .andExpect(jsonPath("$.eventId").value(eventId))
+                .andExpect(jsonPath("$.author.id").value(commentDto.getAuthor().getId()))
+                .andExpect(jsonPath("$.author.name").value(commentDto.getAuthor().getName()))
+                .andExpect(jsonPath("$.isEdited").value(false));
+    }
+
+    @Test
+    void createComment_whenInvalidText_thenReturnsBadRequest() throws Exception {
+        NewCommentDto invalidDto = NewCommentDto.builder()
+                .text("") // некорректный: пустая строка
+                .build();
+
+        mockMvc.perform(post("/users/{userId}/comments?eventId={eventId}", userId, eventId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(invalidDto)))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void createComment_whenNegativeUserId_thenReturnsBadRequest() throws Exception {
+        mockMvc.perform(post("/users/{userId}/comments?eventId={eventId}", -1, eventId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(newCommentDto)))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void createComment_whenNegativeEventId_thenReturnsBadRequest() throws Exception {
+        mockMvc.perform(post("/users/{userId}/comments?eventId={eventId}", userId, -1)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(newCommentDto)))
+                .andExpect(status().isBadRequest());
+    }
+
+}

--- a/main-service/src/test/java/ru/practicum/explorewithme/main/controller/priv/PrivateCommentControllerTest.java
+++ b/main-service/src/test/java/ru/practicum/explorewithme/main/controller/priv/PrivateCommentControllerTest.java
@@ -189,21 +189,6 @@ public class PrivateCommentControllerTest {
         }
 
         @Test
-        void updateComment_shouldReturnBadRequest_whenBodyTextTooShort() throws Exception {
-
-            UpdateCommentDto updateCommentDto = UpdateCommentDto.builder()
-                    .text("")
-                    .build();
-
-            mockMvc.perform(patch("/users/{userId}/comments/{commentId}", userId, commentDto.getId())
-                            .contentType(MediaType.APPLICATION_JSON)
-                            .content(objectMapper.writeValueAsString(updateCommentDto)))
-                    .andExpect(status().isBadRequest())
-                    .andExpect(jsonPath("$.errors[0]").exists())
-                    .andExpect(jsonPath("$.errors[0]").value("text: Comment text must be between 1 and 2000 characters."));
-        }
-
-        @Test
         void updateComment_shouldReturnBadRequest_whenBodyTextTooLong() throws Exception {
             String longText = "a".repeat(2001);
             UpdateCommentDto updateCommentDto = UpdateCommentDto.builder()

--- a/main-service/src/test/java/ru/practicum/explorewithme/main/controller/priv/PrivateCommentControllerTest.java
+++ b/main-service/src/test/java/ru/practicum/explorewithme/main/controller/priv/PrivateCommentControllerTest.java
@@ -71,7 +71,7 @@ public class PrivateCommentControllerTest {
 
     @Nested
     @DisplayName("Набор тестов для метода createComment")
-    class createComment {
+    class CreateComment {
 
         @Test
         void createComment_whenValidInput_thenReturnsCreatedComment() throws Exception {
@@ -121,7 +121,7 @@ public class PrivateCommentControllerTest {
 
     @Nested
     @DisplayName("Набор тестов для метода updateComment")
-    class updateComment {
+    class UpdateComment {
 
         @Test
         void updateComment_shouldReturnUpdatedComment_whenInputIsValid() throws Exception {

--- a/main-service/src/test/java/ru/practicum/explorewithme/main/controller/priv/PrivateCommentControllerTest.java
+++ b/main-service/src/test/java/ru/practicum/explorewithme/main/controller/priv/PrivateCommentControllerTest.java
@@ -2,6 +2,8 @@ package ru.practicum.explorewithme.main.controller.priv;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -67,157 +69,163 @@ public class PrivateCommentControllerTest {
                 .build();
     }
 
-    // тесты для создания
+    @Nested
+    @DisplayName("Набор тестов для метода createComment")
+    class createComment {
 
-    @Test
-    void createComment_whenValidInput_thenReturnsCreatedComment() throws Exception {
-        when(commentService.addComment(eq(userId), eq(eventId), any(NewCommentDto.class)))
-                .thenReturn(commentDto);
+        @Test
+        void createComment_whenValidInput_thenReturnsCreatedComment() throws Exception {
+            when(commentService.addComment(eq(userId), eq(eventId), any(NewCommentDto.class)))
+                    .thenReturn(commentDto);
 
-        mockMvc.perform(post("/users/{userId}/comments?eventId={eventId}", userId, eventId)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(newCommentDto)))
-                .andExpect(status().isCreated())
-                .andExpect(jsonPath("$.id").value(commentDto.getId()))
-                .andExpect(jsonPath("$.text").value(commentDto.getText()))
-                .andExpect(jsonPath("$.eventId").value(eventId))
-                .andExpect(jsonPath("$.author.id").value(commentDto.getAuthor().getId()))
-                .andExpect(jsonPath("$.author.name").value(commentDto.getAuthor().getName()))
-                .andExpect(jsonPath("$.isEdited").value(false));
+            mockMvc.perform(post("/users/{userId}/comments?eventId={eventId}", userId, eventId)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(newCommentDto)))
+                    .andExpect(status().isCreated())
+                    .andExpect(jsonPath("$.id").value(commentDto.getId()))
+                    .andExpect(jsonPath("$.text").value(commentDto.getText()))
+                    .andExpect(jsonPath("$.eventId").value(eventId))
+                    .andExpect(jsonPath("$.author.id").value(commentDto.getAuthor().getId()))
+                    .andExpect(jsonPath("$.author.name").value(commentDto.getAuthor().getName()))
+                    .andExpect(jsonPath("$.isEdited").value(false));
+        }
+
+        @Test
+        void createComment_whenInvalidText_thenReturnsBadRequest() throws Exception {
+            NewCommentDto invalidDto = NewCommentDto.builder()
+                    .text("")
+                    .build();
+
+            mockMvc.perform(post("/users/{userId}/comments?eventId={eventId}", userId, eventId)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(invalidDto)))
+                    .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        void createComment_whenNegativeUserId_thenReturnsBadRequest() throws Exception {
+            mockMvc.perform(post("/users/{userId}/comments?eventId={eventId}", -1, eventId)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(newCommentDto)))
+                    .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        void createComment_whenNegativeEventId_thenReturnsBadRequest() throws Exception {
+            mockMvc.perform(post("/users/{userId}/comments?eventId={eventId}", userId, -1)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(newCommentDto)))
+                    .andExpect(status().isBadRequest());
+        }
     }
 
-    @Test
-    void createComment_whenInvalidText_thenReturnsBadRequest() throws Exception {
-        NewCommentDto invalidDto = NewCommentDto.builder()
-                .text("") // некорректный: пустая строка
-                .build();
+    @Nested
+    @DisplayName("Набор тестов для метода updateComment")
+    class updateComment {
 
-        mockMvc.perform(post("/users/{userId}/comments?eventId={eventId}", userId, eventId)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(invalidDto)))
-                .andExpect(status().isBadRequest());
-    }
+        @Test
+        void updateComment_shouldReturnUpdatedComment_whenInputIsValid() throws Exception {
+            Long commentId = commentDto.getId();
 
-    @Test
-    void createComment_whenNegativeUserId_thenReturnsBadRequest() throws Exception {
-        mockMvc.perform(post("/users/{userId}/comments?eventId={eventId}", -1, eventId)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(newCommentDto)))
-                .andExpect(status().isBadRequest());
-    }
+            UpdateCommentDto updateCommentDto = UpdateCommentDto.builder()
+                    .text("Updated text")
+                    .build();
 
-    @Test
-    void createComment_whenNegativeEventId_thenReturnsBadRequest() throws Exception {
-        mockMvc.perform(post("/users/{userId}/comments?eventId={eventId}", userId, -1)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(newCommentDto)))
-                .andExpect(status().isBadRequest());
-    }
+            CommentDto updatedComment = CommentDto.builder()
+                    .id(commentId)
+                    .text(updateCommentDto.getText())
+                    .author(commentDto.getAuthor())
+                    .eventId(eventId)
+                    .createdOn(commentDto.getCreatedOn())
+                    .updatedOn(commentDto.getUpdatedOn())
+                    .isEdited(true)
+                    .build();
 
-    //тесты для обновления
+            when(commentService.updateUserComment(eq(userId), eq(commentId), any(UpdateCommentDto.class)))
+                    .thenReturn(updatedComment);
 
-    @Test
-    void updateComment_shouldReturnUpdatedComment_whenInputIsValid() throws Exception {
-        Long commentId = commentDto.getId();
+            mockMvc.perform(patch("/users/{userId}/comments/{commentId}", userId, commentId)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(updateCommentDto)))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.id").value(commentId))
+                    .andExpect(jsonPath("$.text").value(updateCommentDto.getText()))
+                    .andExpect(jsonPath("$.author.id").value(commentDto.getAuthor().getId()))
+                    .andExpect(jsonPath("$.isEdited").value(true));
 
-        UpdateCommentDto updateCommentDto = UpdateCommentDto.builder()
-                .text("Updated text")
-                .build();
+            verify(commentService, times(1))
+                    .updateUserComment(eq(userId), eq(commentId), any(UpdateCommentDto.class));
+        }
 
-        CommentDto updatedComment = CommentDto.builder()
-                .id(commentId)
-                .text(updateCommentDto.getText())
-                .author(commentDto.getAuthor())
-                .eventId(eventId)
-                .createdOn(commentDto.getCreatedOn())
-                .updatedOn(commentDto.getUpdatedOn())
-                .isEdited(true)
-                .build();
+        @Test
+        void updateComment_shouldReturnBadRequest_whenPathVariablesInvalid() throws Exception {
+            UpdateCommentDto updateCommentDto = UpdateCommentDto.builder()
+                    .text("Comment text")
+                    .build();
 
-        when(commentService.updateUserComment(eq(userId), eq(commentId), any(UpdateCommentDto.class)))
-                .thenReturn(updatedComment);
+            mockMvc.perform(patch("/users/{userId}/comments/{commentId}", -1, 10)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(updateCommentDto)))
+                    .andExpect(status().isBadRequest());
 
-        mockMvc.perform(patch("/users/{userId}/comments/{commentId}", userId, commentId)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(updateCommentDto)))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.id").value(commentId))
-                .andExpect(jsonPath("$.text").value(updateCommentDto.getText()))
-                .andExpect(jsonPath("$.author.id").value(commentDto.getAuthor().getId()))
-                .andExpect(jsonPath("$.isEdited").value(true));
+            mockMvc.perform(patch("/users/{userId}/comments/{commentId}", 1, -10)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(updateCommentDto)))
+                    .andExpect(status().isBadRequest());
+        }
 
-        verify(commentService, times(1))
-                .updateUserComment(eq(userId), eq(commentId), any(UpdateCommentDto.class));
-    }
+        @Test
+        void updateComment_shouldReturnBadRequest_whenBodyTextBlank() throws Exception {
+            UpdateCommentDto updateCommentDto = UpdateCommentDto.builder()
+                    .text("   ")
+                    .build();
 
-    @Test
-    void updateComment_shouldReturnBadRequest_whenPathVariablesInvalid() throws Exception {
-        UpdateCommentDto updateCommentDto = UpdateCommentDto.builder()
-                .text("Comment text")
-                .build();
+            mockMvc.perform(patch("/users/{userId}/comments/{commentId}", userId, commentDto.getId())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(updateCommentDto)))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.errors[0]").exists())
+                    .andExpect(jsonPath("$.errors[0]").value("text: Comment text cannot be blank."));
+        }
 
-        mockMvc.perform(patch("/users/{userId}/comments/{commentId}", -1, 10)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(updateCommentDto)))
-                .andExpect(status().isBadRequest());
+        @Test
+        void updateComment_shouldReturnBadRequest_whenBodyTextTooShort() throws Exception {
 
-        mockMvc.perform(patch("/users/{userId}/comments/{commentId}", 1, -10)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(updateCommentDto)))
-                .andExpect(status().isBadRequest());
-    }
+            UpdateCommentDto updateCommentDto = UpdateCommentDto.builder()
+                    .text("")
+                    .build();
 
-    @Test
-    void updateComment_shouldReturnBadRequest_whenBodyTextBlank() throws Exception {
-        UpdateCommentDto updateCommentDto = UpdateCommentDto.builder()
-                .text("   ")
-                .build();
+            mockMvc.perform(patch("/users/{userId}/comments/{commentId}", userId, commentDto.getId())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(updateCommentDto)))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.errors[0]").exists())
+                    .andExpect(jsonPath("$.errors[0]").value("text: Comment text must be between 1 and 2000 characters."));
+        }
 
-        mockMvc.perform(patch("/users/{userId}/comments/{commentId}", userId, commentDto.getId())
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(updateCommentDto)))
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.errors[0]").exists())
-                .andExpect(jsonPath("$.errors[0]").value("text: Comment text cannot be blank."));
-    }
+        @Test
+        void updateComment_shouldReturnBadRequest_whenBodyTextTooLong() throws Exception {
+            String longText = "a".repeat(2001);
+            UpdateCommentDto updateCommentDto = UpdateCommentDto.builder()
+                    .text(longText)
+                    .build();
 
-    @Test
-    void updateComment_shouldReturnBadRequest_whenBodyTextTooShort() throws Exception {
+            mockMvc.perform(patch("/users/{userId}/comments/{commentId}", userId, commentDto.getId())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(updateCommentDto)))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.errors[0]").exists())
+                    .andExpect(jsonPath("$.errors[0]").value("text: Comment text must be between 1 and 2000 characters."));
+        }
 
-        UpdateCommentDto updateCommentDto = UpdateCommentDto.builder()
-                .text("")
-                .build();
-
-        mockMvc.perform(patch("/users/{userId}/comments/{commentId}", userId, commentDto.getId())
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(updateCommentDto)))
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.errors[0]").exists())
-                .andExpect(jsonPath("$.errors[0]").value("text: Comment text must be between 1 and 2000 characters."));
-    }
-
-    @Test
-    void updateComment_shouldReturnBadRequest_whenBodyTextTooLong() throws Exception {
-        String longText = "a".repeat(2001);
-        UpdateCommentDto updateCommentDto = UpdateCommentDto.builder()
-                .text(longText)
-                .build();
-
-        mockMvc.perform(patch("/users/{userId}/comments/{commentId}", userId, commentDto.getId())
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(updateCommentDto)))
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.errors[0]").exists())
-                .andExpect(jsonPath("$.errors[0]").value("text: Comment text must be between 1 and 2000 characters."));
-    }
-
-    @Test
-    void updateComment_shouldReturnBadRequest_whenBodyEmpty() throws Exception {
-        mockMvc.perform(patch("/users/{userId}/comments/{commentId}", userId, commentDto.getId())
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content("{}"))
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.errors[0]").exists())
-                .andExpect(jsonPath("$.errors[0]").value("text: Comment text cannot be blank."));
+        @Test
+        void updateComment_shouldReturnBadRequest_whenBodyEmpty() throws Exception {
+            mockMvc.perform(patch("/users/{userId}/comments/{commentId}", userId, commentDto.getId())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("{}"))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.errors[0]").exists())
+                    .andExpect(jsonPath("$.errors[0]").value("text: Comment text cannot be blank."));
+        }
     }
 }

--- a/main-service/src/test/java/ru/practicum/explorewithme/main/controller/priv/PrivateCommentControllerTest.java
+++ b/main-service/src/test/java/ru/practicum/explorewithme/main/controller/priv/PrivateCommentControllerTest.java
@@ -193,7 +193,7 @@ public class PrivateCommentControllerTest {
                         .content(objectMapper.writeValueAsString(updateCommentDto)))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.errors[0]").exists())
-                .andExpect(jsonPath("$.errors[0]").value("text: Comment text cannot be blank."));
+                .andExpect(jsonPath("$.errors[0]").value("text: Comment text must be between 1 and 2000 characters."));
     }
 
     @Test

--- a/main-service/src/test/java/ru/practicum/explorewithme/main/service/CommentServiceImplTest.java
+++ b/main-service/src/test/java/ru/practicum/explorewithme/main/service/CommentServiceImplTest.java
@@ -1,0 +1,117 @@
+package ru.practicum.explorewithme.main.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import ru.practicum.explorewithme.main.dto.CommentDto;
+import ru.practicum.explorewithme.main.dto.NewCommentDto;
+import ru.practicum.explorewithme.main.error.BusinessRuleViolationException;
+import ru.practicum.explorewithme.main.error.EntityNotFoundException;
+import ru.practicum.explorewithme.main.mapper.CommentMapper;
+import ru.practicum.explorewithme.main.model.Comment;
+import ru.practicum.explorewithme.main.model.Event;
+import ru.practicum.explorewithme.main.model.EventState;
+import ru.practicum.explorewithme.main.model.User;
+import ru.practicum.explorewithme.main.repository.CommentRepository;
+import ru.practicum.explorewithme.main.repository.EventRepository;
+import ru.practicum.explorewithme.main.repository.UserRepository;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class CommentServiceImplTest {
+
+    @Mock
+    private UserRepository userRepository;
+    @Mock
+    private EventRepository eventRepository;
+    @Mock
+    private CommentMapper commentMapper;
+    @Mock
+    private CommentRepository commentRepository;
+
+    @InjectMocks
+    private CommentServiceImpl commentService;
+
+    private long userId;
+    private long eventId;
+    private User user;
+    private Event event;
+
+    @BeforeEach
+    void setUp() {
+        userId = 1L;
+        eventId = 2L;
+        user = new User();
+        event = new Event();
+    }
+
+    @Test
+    void addComment_success() {
+        NewCommentDto newCommentDto = new NewCommentDto();
+        event.setState(EventState.PUBLISHED);
+        event.setCommentsEnabled(true);
+        Comment comment = new Comment();
+        CommentDto commentDto = new CommentDto();
+
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+        when(eventRepository.findById(eventId)).thenReturn(Optional.of(event));
+        when(commentMapper.toComment(newCommentDto)).thenReturn(comment);
+        when(commentMapper.toDto(comment)).thenReturn(commentDto);
+
+        CommentDto result = commentService.addComment(userId, eventId, newCommentDto);
+
+        assertEquals(commentDto, result);
+        verify(commentRepository, times(1)).save(comment);
+        assertEquals(user, comment.getAuthor());
+        assertEquals(event, comment.getEvent());
+    }
+
+    @Test
+    void addComment_userNotFound() {
+        when(userRepository.findById(userId)).thenReturn(Optional.empty());
+
+        EntityNotFoundException ex = assertThrows(EntityNotFoundException.class,
+                () -> commentService.addComment(userId, 2L, new NewCommentDto()));
+        assertTrue(ex.getMessage().contains("Пользователь с id " + userId + " не найден"));
+    }
+
+    @Test
+    void addComment_eventNotFound() {
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+        when(eventRepository.findById(eventId)).thenReturn(Optional.empty());
+
+        EntityNotFoundException ex = assertThrows(EntityNotFoundException.class,
+                () -> commentService.addComment(userId, eventId, new NewCommentDto()));
+        assertTrue(ex.getMessage().contains("Событие с id " + eventId + " не найден"));
+    }
+
+    @Test
+    void addComment_eventNotPublished() {
+        event.setState(EventState.PENDING); // не опубликовано
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+        when(eventRepository.findById(eventId)).thenReturn(Optional.of(event));
+
+        BusinessRuleViolationException ex = assertThrows(BusinessRuleViolationException.class,
+                () -> commentService.addComment(userId, eventId, new NewCommentDto()));
+        assertEquals("Событие еще не опубликовано", ex.getMessage());
+    }
+
+    @Test
+    void addComment_commentsDisabled() {
+        event.setState(EventState.PUBLISHED);
+        event.setCommentsEnabled(false); // Комментарии запрещены
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+        when(eventRepository.findById(eventId)).thenReturn(Optional.of(event));
+
+        BusinessRuleViolationException ex = assertThrows(BusinessRuleViolationException.class,
+                () -> commentService.addComment(userId, eventId, new NewCommentDto()));
+        assertEquals("Комментарии запрещены", ex.getMessage());
+    }
+}

--- a/main-service/src/test/java/ru/practicum/explorewithme/main/service/CommentServiceImplTest.java
+++ b/main-service/src/test/java/ru/practicum/explorewithme/main/service/CommentServiceImplTest.java
@@ -69,7 +69,7 @@ class CommentServiceImplTest {
 
     @Nested
     @DisplayName("Набор тестов для метода addComment")
-    class addComment {
+    class AddComment {
 
         @Test
         void addComment_success() {
@@ -138,7 +138,7 @@ class CommentServiceImplTest {
 
     @Nested
     @DisplayName("Набор тестов для метода updateUserComment")
-    class updateUserComment {
+    class UpdateUserComment {
 
         @Test
         void updateUserComment_shouldUpdateCommentAndReturnDto() {


### PR DESCRIPTION
Реализован эндпоинт POST /users/{userId}/comments?eventId={eventId} и соответствующая логика сервиса для создания нового комментария авторизованным пользователем.

Реализован эндпоинт PATCH /users/{userId}/comments/{commentId} и соответствующая логика сервиса для обновления пользователем текста своего комментария. Обновление возможно только в течение 6 часов после создания и если комментарий не был "мягко" удален.

Прописаны:
- Service (CommentService интерфейс и CommentServiceImpl);
- Controller (PrivateCommentController);
- Юнит-тесты для сервиса и контроллера.