### PR TITLE
Comments Admin API: Получение списка комментариев с фильтрацией

### DIFF
--- a/.run/stats-local.run.xml
+++ b/.run/stats-local.run.xml
@@ -6,7 +6,7 @@
     <module name="stats-server" />
     <option name="VM_PARAMETERS" value="-Dspring.profiles.active=local" />
     <method v="2">
-      <option name="RunConfigurationTask" enabled="true" run_configuration_name="db-services" run_configuration_type="docker-deploy" />
+      <option name="RunConfigurationTask" enabled="true" run_configuration_name="stats-db" run_configuration_type="docker-deploy" />
     </method>
   </configuration>
 </component>

--- a/main-service/src/main/java/ru/practicum/explorewithme/main/controller/admin/AdminCommentController.java
+++ b/main-service/src/main/java/ru/practicum/explorewithme/main/controller/admin/AdminCommentController.java
@@ -58,8 +58,8 @@ public class AdminCommentController {
     @GetMapping
     @ResponseStatus(HttpStatus.OK)
     public List<CommentDto> getAllCommentsAdmin(
-        @RequestParam(name = "userId", required = false) Long userId,
-        @RequestParam(name = "eventId", required = false) Long eventId,
+        @RequestParam(name = "userId", required = false) @Positive Long userId,
+        @RequestParam(name = "eventId", required = false) @Positive Long eventId,
         @RequestParam(name = "isDeleted", required = false) Boolean isDeleted,
         @RequestParam(name = "from", defaultValue = "0") @PositiveOrZero int from,
         @RequestParam(name = "size", defaultValue = "10") @Positive int size) {

--- a/main-service/src/main/java/ru/practicum/explorewithme/main/controller/admin/AdminCommentController.java
+++ b/main-service/src/main/java/ru/practicum/explorewithme/main/controller/admin/AdminCommentController.java
@@ -1,13 +1,23 @@
 package ru.practicum.explorewithme.main.controller.admin;
 
 import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.PositiveOrZero;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
 import ru.practicum.explorewithme.main.dto.CommentDto;
 import ru.practicum.explorewithme.main.service.CommentService;
+import ru.practicum.explorewithme.main.service.params.AdminCommentSearchParams;
 
 @RestController
 @RequestMapping("/admin/comments")
@@ -33,5 +43,39 @@ public class AdminCommentController {
         CommentDto restoredComment = commentService.restoreCommentByAdmin(commentId);
         log.info("Admin: Comment with Id: {} restored", commentId);
         return restoredComment;
+    }
+
+    /**
+     * Получение списка всех комментариев с возможностью фильтрации администратором.
+     *
+     * @param userId    ID автора комментария для фильтрации (опционально)
+     * @param eventId   ID события для фильтрации (опционально)
+     * @param isDeleted Фильтр по статусу удаления (true - удаленные, false - не удаленные, null - все) (опционально)
+     * @param from      количество элементов, которые нужно пропустить для формирования текущего набора
+     * @param size      количество элементов в наборе
+     * @return Список CommentDto
+     */
+    @GetMapping
+    @ResponseStatus(HttpStatus.OK)
+    public List<CommentDto> getAllCommentsAdmin(
+        @RequestParam(name = "userId", required = false) Long userId,
+        @RequestParam(name = "eventId", required = false) Long eventId,
+        @RequestParam(name = "isDeleted", required = false) Boolean isDeleted,
+        @RequestParam(name = "from", defaultValue = "0") @PositiveOrZero int from,
+        @RequestParam(name = "size", defaultValue = "10") @Positive int size) {
+
+        log.info("Admin: Received request to get all comments with filters: userId={}, eventId={}, isDeleted={}, from={}, size={}",
+            userId, eventId, isDeleted, from, size);
+
+        AdminCommentSearchParams searchParams = AdminCommentSearchParams.builder()
+            .userId(userId)
+            .eventId(eventId)
+            .isDeleted(isDeleted)
+            .build();
+
+        List<CommentDto> comments = commentService.getAllCommentsAdmin(searchParams, from, size);
+
+        log.info("Admin: Found {} comments matching criteria.", comments.size());
+        return comments;
     }
 }

--- a/main-service/src/main/java/ru/practicum/explorewithme/main/repository/CommentRepository.java
+++ b/main-service/src/main/java/ru/practicum/explorewithme/main/repository/CommentRepository.java
@@ -1,16 +1,24 @@
 package ru.practicum.explorewithme.main.repository;
 
 
+import com.querydsl.core.types.Predicate;
+import org.jetbrains.annotations.NotNull;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.querydsl.QuerydslPredicateExecutor;
 import ru.practicum.explorewithme.main.model.Comment;
 
-public interface CommentRepository extends JpaRepository<Comment, Long> {
+public interface CommentRepository extends JpaRepository<Comment, Long>,
+    QuerydslPredicateExecutor<Comment> {
 
     @EntityGraph(attributePaths = {"author"})
     Page<Comment> findByEventIdAndIsDeletedFalse(Long eventId, Pageable pageable);
+
+    @EntityGraph(attributePaths = {"author"})
+    @Override
+    @NotNull Page<Comment> findAll(@NotNull Predicate predicate, @NotNull Pageable pageable);
 
     @EntityGraph(attributePaths = {"author"})
     Page<Comment> findByAuthorIdAndIsDeletedFalse(Long authorId, Pageable pageable);

--- a/main-service/src/main/java/ru/practicum/explorewithme/main/service/CommentService.java
+++ b/main-service/src/main/java/ru/practicum/explorewithme/main/service/CommentService.java
@@ -3,13 +3,14 @@ package ru.practicum.explorewithme.main.service;
 import ru.practicum.explorewithme.main.dto.CommentDto;
 import ru.practicum.explorewithme.main.dto.NewCommentDto;
 import ru.practicum.explorewithme.main.dto.UpdateCommentDto;
+import ru.practicum.explorewithme.main.service.params.AdminCommentSearchParams;
 import ru.practicum.explorewithme.main.service.params.PublicCommentParameters;
 
 import java.util.List;
 
 public interface CommentService {
 
-    List<CommentDto> getCommentsForEvent(Long eventId, PublicCommentParameters commentParameters);
+    List<CommentDto> getCommentsForEvent(Long eventId, PublicCommentParameters publicCommentParameters);
 
     List<CommentDto> getUserComments(Long userId, int from, int size);
 
@@ -22,4 +23,6 @@ public interface CommentService {
     void deleteUserComment(Long userId, Long commentId);
 
     CommentDto restoreCommentByAdmin(Long commentId);
+
+    List<CommentDto> getAllCommentsAdmin(AdminCommentSearchParams searchParams, int from, int size);
 }

--- a/main-service/src/main/java/ru/practicum/explorewithme/main/service/CommentServiceImpl.java
+++ b/main-service/src/main/java/ru/practicum/explorewithme/main/service/CommentServiceImpl.java
@@ -191,10 +191,6 @@ public class CommentServiceImpl implements CommentService {
 
         Page<Comment> commentPage = commentRepository.findAll(predicate, pageable);
 
-        if (commentPage.isEmpty()) {
-            return Collections.emptyList();
-        }
-
         List<CommentDto> result = commentMapper.toDtoList(commentPage.getContent());
         log.debug("Admin: Found {} comments for the given criteria.", result.size());
         return result;

--- a/main-service/src/main/java/ru/practicum/explorewithme/main/service/CommentServiceImpl.java
+++ b/main-service/src/main/java/ru/practicum/explorewithme/main/service/CommentServiceImpl.java
@@ -1,6 +1,14 @@
 package ru.practicum.explorewithme.main.service;
 
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.Predicate;
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -15,10 +23,12 @@ import ru.practicum.explorewithme.main.mapper.CommentMapper;
 import ru.practicum.explorewithme.main.model.Comment;
 import ru.practicum.explorewithme.main.model.Event;
 import ru.practicum.explorewithme.main.model.EventState;
+import ru.practicum.explorewithme.main.model.QComment;
 import ru.practicum.explorewithme.main.model.User;
 import ru.practicum.explorewithme.main.repository.CommentRepository;
 import ru.practicum.explorewithme.main.repository.EventRepository;
 import ru.practicum.explorewithme.main.repository.UserRepository;
+import ru.practicum.explorewithme.main.service.params.AdminCommentSearchParams;
 import ru.practicum.explorewithme.main.service.params.PublicCommentParameters;
 
 import java.time.LocalDateTime;
@@ -27,6 +37,7 @@ import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class CommentServiceImpl implements CommentService {
 
     private final UserRepository userRepository;
@@ -155,5 +166,39 @@ public class CommentServiceImpl implements CommentService {
             commentRepository.save(comment);
         }
         return commentMapper.toDto(comment);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<CommentDto> getAllCommentsAdmin(AdminCommentSearchParams searchParams, int from, int size) {
+        log.debug("Admin: Searching all comments with params: {}, from={}, size={}", searchParams, from, size);
+
+        QComment qComment = QComment.comment;
+        BooleanBuilder predicate = new BooleanBuilder();
+
+        if (searchParams.getUserId() != null) {
+            predicate.and(qComment.author.id.eq(searchParams.getUserId()));
+        }
+
+        if (searchParams.getEventId() != null) {
+            predicate.and(qComment.event.id.eq(searchParams.getEventId()));
+        }
+
+        if (searchParams.getIsDeleted() != null) {
+            predicate.and(qComment.isDeleted.eq(searchParams.getIsDeleted()));
+        }
+
+        Pageable pageable = PageRequest.of(from / size, size, Sort.by(Sort.Direction.DESC, "createdOn"));
+
+        Predicate finalPredicate = predicate.getValue();
+        Page<Comment> commentPage = commentRepository.findAll(finalPredicate, pageable);
+
+        if (commentPage.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        List<CommentDto> result = commentMapper.toDtoList(commentPage.getContent());
+        log.debug("Admin: Found {} comments for the given criteria.", result.size());
+        return result;
     }
 }

--- a/main-service/src/main/java/ru/practicum/explorewithme/main/service/CommentServiceImpl.java
+++ b/main-service/src/main/java/ru/practicum/explorewithme/main/service/CommentServiceImpl.java
@@ -1,7 +1,6 @@
 package ru.practicum.explorewithme.main.service;
 
 import com.querydsl.core.BooleanBuilder;
-import com.querydsl.core.types.Predicate;
 import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.List;
@@ -190,8 +189,7 @@ public class CommentServiceImpl implements CommentService {
 
         Pageable pageable = PageRequest.of(from / size, size, Sort.by(Sort.Direction.DESC, "createdOn"));
 
-        Predicate finalPredicate = predicate.getValue();
-        Page<Comment> commentPage = commentRepository.findAll(finalPredicate, pageable);
+        Page<Comment> commentPage = commentRepository.findAll(predicate, pageable);
 
         if (commentPage.isEmpty()) {
             return Collections.emptyList();

--- a/main-service/src/main/java/ru/practicum/explorewithme/main/service/CommentServiceImpl.java
+++ b/main-service/src/main/java/ru/practicum/explorewithme/main/service/CommentServiceImpl.java
@@ -2,7 +2,6 @@ package ru.practicum.explorewithme.main.service;
 
 import com.querydsl.core.BooleanBuilder;
 import java.time.LocalDateTime;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
@@ -29,10 +28,6 @@ import ru.practicum.explorewithme.main.repository.EventRepository;
 import ru.practicum.explorewithme.main.repository.UserRepository;
 import ru.practicum.explorewithme.main.service.params.AdminCommentSearchParams;
 import ru.practicum.explorewithme.main.service.params.PublicCommentParameters;
-
-import java.time.LocalDateTime;
-import java.util.List;
-import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor

--- a/main-service/src/main/java/ru/practicum/explorewithme/main/service/EventServiceImpl.java
+++ b/main-service/src/main/java/ru/practicum/explorewithme/main/service/EventServiceImpl.java
@@ -109,7 +109,7 @@ public class EventServiceImpl implements EventService {
 
         Pageable pageable = PageRequest.of(from / size, size, sortOption);
 
-        Page<Event> eventPage = eventRepository.findAll(predicate.getValue(), pageable);
+        Page<Event> eventPage = eventRepository.findAll(predicate, pageable);
 
         if (eventPage.isEmpty()) {
             return Collections.emptyList();

--- a/main-service/src/main/java/ru/practicum/explorewithme/main/service/params/AdminCommentSearchParams.java
+++ b/main-service/src/main/java/ru/practicum/explorewithme/main/service/params/AdminCommentSearchParams.java
@@ -1,0 +1,14 @@
+package ru.practicum.explorewithme.main.service.params;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class AdminCommentSearchParams {
+    private final Long userId;
+    private final Long eventId;
+    private final Boolean isDeleted;
+}

--- a/main-service/src/main/java/ru/practicum/explorewithme/main/service/params/AdminCommentSearchParams.java
+++ b/main-service/src/main/java/ru/practicum/explorewithme/main/service/params/AdminCommentSearchParams.java
@@ -2,11 +2,13 @@ package ru.practicum.explorewithme.main.service.params;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
 @Getter
 @Builder
 @AllArgsConstructor
+@EqualsAndHashCode
 public class AdminCommentSearchParams {
     private final Long userId;
     private final Long eventId;

--- a/main-service/src/main/resources/application-test.yaml
+++ b/main-service/src/main/resources/application-test.yaml
@@ -1,0 +1,8 @@
+logging:
+  level:
+    org.hibernate.SQL: DEBUG
+    org.hibernate.type.descriptor.sql.BasicBinder: TRACE
+spring:
+  jpa:
+    properties:
+      hibernate.generate_statistics: true

--- a/main-service/src/test/java/ru/practicum/explorewithme/main/controller/admin/AdminCommentControllerTest.java
+++ b/main-service/src/test/java/ru/practicum/explorewithme/main/controller/admin/AdminCommentControllerTest.java
@@ -1,0 +1,201 @@
+package ru.practicum.explorewithme.main.controller.admin;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested; // Добавлен импорт Nested
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import ru.practicum.explorewithme.main.dto.CommentDto;
+import ru.practicum.explorewithme.main.dto.UserShortDto;
+import ru.practicum.explorewithme.main.service.CommentService;
+import ru.practicum.explorewithme.main.service.params.AdminCommentSearchParams;
+
+@WebMvcTest(AdminCommentController.class)
+@DisplayName("Тесты для AdminCommentController")
+class AdminCommentControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private CommentService commentService;
+
+    @Captor
+    private ArgumentCaptor<AdminCommentSearchParams> paramsCaptor;
+
+    @Nested
+    @DisplayName("Метод GET /admin/comments")
+    class GetAllCommentsAdminTests {
+
+        @Test
+        @DisplayName("Должен вернуть 200 OK и пустой список, если комментариев не найдено")
+        void whenNoCommentsFound_shouldReturnOkAndEmptyList() throws Exception {
+            when(commentService.getAllCommentsAdmin(any(AdminCommentSearchParams.class), eq(0), eq(10)))
+                .thenReturn(Collections.emptyList());
+
+            mockMvc.perform(get("/admin/comments")
+                    .param("from", "0")
+                    .param("size", "10")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .characterEncoding(StandardCharsets.UTF_8))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(0)));
+
+            verify(commentService).getAllCommentsAdmin(paramsCaptor.capture(), eq(0), eq(10));
+            AdminCommentSearchParams capturedParams = paramsCaptor.getValue();
+            assertNull(capturedParams.getUserId());
+            assertNull(capturedParams.getEventId());
+            assertNull(capturedParams.getIsDeleted());
+        }
+
+        @Test
+        @DisplayName("Должен вернуть 200 OK и список CommentDto, если комментарии найдены")
+        void whenCommentsFound_shouldReturnOkAndDtoList() throws Exception {
+            UserShortDto author = UserShortDto.builder().id(1L).name("Test Author").build();
+            CommentDto comment1 = CommentDto.builder().id(1L).text("Comment 1").author(author).eventId(100L).createdOn(LocalDateTime.now()).build();
+            CommentDto comment2 = CommentDto.builder().id(2L).text("Comment 2").author(author).eventId(101L).createdOn(LocalDateTime.now()).build();
+            List<CommentDto> comments = List.of(comment1, comment2);
+
+            when(commentService.getAllCommentsAdmin(any(AdminCommentSearchParams.class), eq(0), eq(10)))
+                .thenReturn(comments);
+
+            mockMvc.perform(get("/admin/comments")
+                    .param("from", "0")
+                    .param("size", "10")
+                    .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(2)))
+                .andExpect(jsonPath("$[0].id", is(comment1.getId().intValue())))
+                .andExpect(jsonPath("$[0].text", is(comment1.getText())))
+                .andExpect(jsonPath("$[1].id", is(comment2.getId().intValue())))
+                .andExpect(jsonPath("$[1].text", is(comment2.getText())));
+
+            verify(commentService).getAllCommentsAdmin(any(AdminCommentSearchParams.class), eq(0), eq(10));
+        }
+
+        @Test
+        @DisplayName("Должен корректно передавать все параметры фильтрации в сервис")
+        void withAllFilters_shouldPassFiltersToService() throws Exception {
+            Long userIdFilter = 1L;
+            Long eventIdFilter = 10L;
+            Boolean isDeletedFilter = false;
+            int from = 5;
+            int size = 15;
+
+            AdminCommentSearchParams expectedSearchParams = AdminCommentSearchParams.builder()
+                .userId(userIdFilter)
+                .eventId(eventIdFilter)
+                .isDeleted(isDeletedFilter)
+                .build();
+
+            when(commentService.getAllCommentsAdmin(eq(expectedSearchParams), eq(from), eq(size)))
+                .thenReturn(Collections.emptyList());
+
+            mockMvc.perform(get("/admin/comments")
+                    .param("userId", userIdFilter.toString())
+                    .param("eventId", eventIdFilter.toString())
+                    .param("isDeleted", isDeletedFilter.toString())
+                    .param("from", String.valueOf(from))
+                    .param("size", String.valueOf(size))
+                    .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(0)));
+
+            verify(commentService).getAllCommentsAdmin(eq(expectedSearchParams), eq(from), eq(size));
+        }
+
+        @Test
+        @DisplayName("Должен использовать значения по умолчанию для from и size")
+        void withDefaultPagination_shouldUseDefaultValues() throws Exception {
+            AdminCommentSearchParams expectedSearchParams = AdminCommentSearchParams.builder().build();
+            when(commentService.getAllCommentsAdmin(eq(expectedSearchParams), eq(0), eq(10)))
+                .thenReturn(Collections.emptyList());
+
+            mockMvc.perform(get("/admin/comments")
+                    .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk());
+
+            verify(commentService).getAllCommentsAdmin(eq(expectedSearchParams), eq(0), eq(10));
+        }
+
+        @Test
+        @DisplayName("Должен вернуть 400 Bad Request при невалидном 'from'")
+        void withInvalidFrom_shouldReturnBadRequest() throws Exception {
+            mockMvc.perform(get("/admin/comments")
+                    .param("from", "-1")
+                    .param("size", "10")
+                    .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest());
+            verifyNoInteractions(commentService);
+        }
+
+        @Test
+        @DisplayName("Должен вернуть 400 Bad Request при невалидном 'size'")
+        void withInvalidSize_shouldReturnBadRequest() throws Exception {
+            mockMvc.perform(get("/admin/comments")
+                    .param("from", "0")
+                    .param("size", "0")
+                    .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest());
+            verifyNoInteractions(commentService);
+        }
+
+        @Test
+        @DisplayName("Должен вернуть 400 Bad Request при невалидном 'userId'")
+        void withInvalidUserIdFormat_shouldReturnBadRequest() throws Exception {
+            mockMvc.perform(get("/admin/comments")
+                    .param("userId", "notANumber")
+                    .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest());
+            verifyNoInteractions(commentService);
+        }
+
+        @Test
+        @DisplayName("Должен вернуть 400 Bad Request при невалидном 'eventId'")
+        void withInvalidEventIdFormat_shouldReturnBadRequest() throws Exception {
+            mockMvc.perform(get("/admin/comments")
+                    .param("eventId", "notANumber")
+                    .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest());
+            verifyNoInteractions(commentService);
+        }
+
+        @Test
+        @DisplayName("Должен вернуть 400 Bad Request при невалидном 'isDeleted'")
+        void withInvalidIsDeletedFormat_shouldReturnBadRequest() throws Exception {
+            mockMvc.perform(get("/admin/comments")
+                    .param("isDeleted", "notABoolean")
+                    .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest());
+            verifyNoInteractions(commentService);
+        }
+    }
+
+    // TODO: тесты для DELETE /{commentId} (deleteCommentByAdmin)
+    // TODO: тесты для PATCH /{commentId}/restore (restoreCommentByAdmin)
+}

--- a/main-service/src/test/java/ru/practicum/explorewithme/main/service/CommentServiceImplTest.java
+++ b/main-service/src/test/java/ru/practicum/explorewithme/main/service/CommentServiceImplTest.java
@@ -1,10 +1,28 @@
 package ru.practicum.explorewithme.main.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.Predicate;
+import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.List;
-import org.junit.jupiter.api.*;
+import java.util.Optional;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
@@ -29,15 +47,7 @@ import ru.practicum.explorewithme.main.model.User;
 import ru.practicum.explorewithme.main.repository.CommentRepository;
 import ru.practicum.explorewithme.main.repository.EventRepository;
 import ru.practicum.explorewithme.main.repository.UserRepository;
-
-import java.time.LocalDateTime;
-import java.util.List;
-import java.util.Optional;
 import ru.practicum.explorewithme.main.service.params.AdminCommentSearchParams;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class CommentServiceImplTest {

--- a/main-service/src/test/java/ru/practicum/explorewithme/main/service/CommentServiceImplTest.java
+++ b/main-service/src/test/java/ru/practicum/explorewithme/main/service/CommentServiceImplTest.java
@@ -1,12 +1,21 @@
 package ru.practicum.explorewithme.main.service;
 
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.Predicate;
+import java.util.Collections;
+import java.util.List;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import ru.practicum.explorewithme.main.dto.CommentDto;
 import ru.practicum.explorewithme.main.dto.NewCommentDto;
 import ru.practicum.explorewithme.main.dto.UpdateCommentDto;
@@ -24,6 +33,7 @@ import ru.practicum.explorewithme.main.repository.UserRepository;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
+import ru.practicum.explorewithme.main.service.params.AdminCommentSearchParams;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
@@ -43,6 +53,12 @@ class CommentServiceImplTest {
 
     @InjectMocks
     private CommentServiceImpl commentService;
+
+    // пока не нужен, но пригодится для тестов Лериных методов
+    @Captor
+    private ArgumentCaptor<Comment> commentArgumentCaptor;
+    @Captor
+    private ArgumentCaptor<Predicate> predicateCaptor;
 
     private long userId;
     private long eventId;
@@ -276,6 +292,270 @@ class CommentServiceImplTest {
             assertThat(exception.getMessage()).contains("Пользователь с id " + userId + " не найден");
             verify(userRepository).existsById(userId);
             verifyNoInteractions(commentRepository, commentMapper);
+        }
+    }
+
+/*
+    тесты для методов из Лериного PR
+
+    @Nested
+    @DisplayName("Метод deleteCommentByAdmin")
+    class DeleteCommentByAdminTests {
+        private Comment existingComment;
+
+        @BeforeEach
+        void setUpDeleteAdmin() {
+            existingComment = new Comment();
+            existingComment.setId(commentId);
+            existingComment.setDeleted(false);
+        }
+
+        @Test
+        @DisplayName("Должен пометить комментарий как удаленный, если он не был удален")
+        void deleteCommentByAdmin_whenNotDeleted_shouldMarkAsDeletedAndSave() {
+            when(commentRepository.findById(commentId)).thenReturn(Optional.of(existingComment));
+            when(commentRepository.save(any(Comment.class))).thenReturn(existingComment);
+
+            commentService.deleteCommentByAdmin(commentId);
+
+            verify(commentRepository).findById(commentId);
+            verify(commentRepository).save(commentCaptor.capture());
+            Comment savedComment = commentCaptor.getValue();
+            assertTrue(savedComment.isDeleted());
+        }
+
+        @Test
+        @DisplayName("Не должен вызывать save, если комментарий уже удален")
+        void deleteCommentByAdmin_whenAlreadyDeleted_shouldDoNothing() {
+            existingComment.setDeleted(true);
+            when(commentRepository.findById(commentId)).thenReturn(Optional.of(existingComment));
+
+            commentService.deleteCommentByAdmin(commentId);
+
+            verify(commentRepository).findById(commentId);
+            verify(commentRepository, never()).save(any(Comment.class));
+        }
+
+        @Test
+        @DisplayName("Должен выбросить EntityNotFoundException, если комментарий не найден")
+        void deleteCommentByAdmin_whenCommentNotFound_shouldThrowEntityNotFoundException() {
+            when(commentRepository.findById(commentId)).thenReturn(Optional.empty());
+
+            EntityNotFoundException ex = assertThrows(EntityNotFoundException.class,
+                () -> commentService.deleteCommentByAdmin(commentId));
+            assertTrue(ex.getMessage().contains("Comment with id=" + commentId + " not found"));
+            verify(commentRepository).findById(commentId);
+            verify(commentRepository, never()).save(any(Comment.class));
+        }
+    }
+
+    @Nested
+    @DisplayName("Метод deleteUserComment")
+    class DeleteUserCommentTests {
+        private Comment userComment;
+        private Long nonAuthorUserId = 999L;
+
+        @BeforeEach
+        void setUpDeleteUser() {
+            userComment = new Comment();
+            userComment.setId(commentId);
+            userComment.setAuthor(user);
+            userComment.setDeleted(false);
+        }
+
+        @Test
+        @DisplayName("Пользователь должен успешно 'мягко' удалять свой комментарий")
+        void deleteUserComment_whenUserIsAuthor_shouldMarkAsDeleted() {
+            when(commentRepository.findById(commentId)).thenReturn(Optional.of(userComment));
+            when(commentRepository.save(any(Comment.class))).thenReturn(userComment);
+
+            commentService.deleteUserComment(userId, commentId);
+
+            verify(commentRepository).findById(commentId);
+            verify(commentRepository).save(commentCaptor.capture());
+            Comment savedComment = commentCaptor.getValue();
+            assertTrue(savedComment.isDeleted());
+        }
+
+        @Test
+        @DisplayName("Должен выбросить EntityNotFoundException, если пользователь не автор")
+        void deleteUserComment_whenUserIsNotAuthor_shouldThrowException() {
+            when(commentRepository.findById(commentId)).thenReturn(Optional.of(userComment));
+
+            EntityNotFoundException ex = assertThrows(EntityNotFoundException.class, () -> {
+                commentService.deleteUserComment(nonAuthorUserId, commentId);
+            });
+            assertTrue(ex.getMessage().contains("is not the author"));
+
+            verify(commentRepository).findById(commentId);
+            verify(commentRepository, never()).save(any(Comment.class));
+        }
+
+        @Test
+        @DisplayName("Не должен вызывать save, если комментарий уже удален пользователем")
+        void deleteUserComment_whenAlreadyDeleted_shouldDoNothing() {
+            userComment.setDeleted(true);
+            when(commentRepository.findById(commentId)).thenReturn(Optional.of(userComment));
+
+            commentService.deleteUserComment(userId, commentId);
+
+            verify(commentRepository).findById(commentId);
+            verify(commentRepository, never()).save(any(Comment.class));
+        }
+
+        @Test
+        @DisplayName("Должен выбросить EntityNotFoundException, если комментарий не найден")
+        void deleteUserComment_whenCommentNotFound_shouldThrowEntityNotFoundException() {
+            when(commentRepository.findById(commentId)).thenReturn(Optional.empty());
+
+            EntityNotFoundException ex = assertThrows(EntityNotFoundException.class,
+                () -> commentService.deleteUserComment(userId, commentId));
+            assertTrue(ex.getMessage().contains("Comment with id=" + commentId + " not found"));
+        }
+    }
+
+    @Nested
+    @DisplayName("Метод restoreCommentByAdmin")
+    class RestoreCommentByAdminTests {
+        private Comment deletedComment;
+        private Comment notDeletedComment;
+        private CommentDto mappedDto;
+
+        @BeforeEach
+        void setUpRestore() {
+            deletedComment = new Comment();
+            deletedComment.setId(commentId);
+            deletedComment.setDeleted(true);
+            deletedComment.setText("Some text");
+
+            notDeletedComment = new Comment();
+            notDeletedComment.setId(commentId + 1);
+            notDeletedComment.setDeleted(false);
+            notDeletedComment.setText("Another text");
+
+            mappedDto = CommentDto.builder().id(commentId).text("Some text").isEdited(false).build();
+        }
+
+        @Test
+        @DisplayName("Должен восстанавливать удаленный комментарий и возвращать DTO")
+        void restoreCommentByAdmin_whenCommentIsDeleted_shouldRestoreAndReturnDto() {
+            when(commentRepository.findById(commentId)).thenReturn(Optional.of(deletedComment));
+            when(commentRepository.save(any(Comment.class))).thenAnswer(invocation -> invocation.getArgument(0));
+            when(commentMapper.toDto(any(Comment.class))).thenReturn(mappedDto);
+
+            CommentDto result = commentService.restoreCommentByAdmin(commentId);
+
+            assertNotNull(result);
+            assertEquals(mappedDto.getText(), result.getText());
+            verify(commentRepository).findById(commentId);
+            verify(commentRepository).save(commentCaptor.capture());
+            Comment savedComment = commentCaptor.getValue();
+            assertFalse(savedComment.isDeleted());
+            verify(commentMapper).toDto(savedComment);
+        }
+
+        @Test
+        @DisplayName("Должен возвращать DTO без изменений, если комментарий не был удален")
+        void restoreCommentByAdmin_whenCommentIsNotDeleted_shouldReturnDtoWithoutSaving() {
+            when(commentRepository.findById(notDeletedComment.getId())).thenReturn(Optional.of(notDeletedComment));
+            when(commentMapper.toDto(notDeletedComment)).thenReturn(
+                CommentDto.builder().id(notDeletedComment.getId()).text(notDeletedComment.getText()).build()
+            );
+
+            CommentDto result = commentService.restoreCommentByAdmin(notDeletedComment.getId());
+
+            assertNotNull(result);
+            assertEquals(notDeletedComment.getText(), result.getText());
+            verify(commentRepository).findById(notDeletedComment.getId());
+            verify(commentRepository, never()).save(any(Comment.class));
+            verify(commentMapper).toDto(notDeletedComment);
+        }
+
+        @Test
+        @DisplayName("Должен выбросить EntityNotFoundException, если комментарий для восстановления не найден")
+        void restoreCommentByAdmin_whenCommentNotFound_shouldThrowEntityNotFoundException() {
+            when(commentRepository.findById(commentId)).thenReturn(Optional.empty());
+
+            EntityNotFoundException ex = assertThrows(EntityNotFoundException.class,
+                () -> commentService.restoreCommentByAdmin(commentId));
+            assertTrue(ex.getMessage().contains("Comment with id=" + commentId + " not found"));
+        }
+    }
+
+ */
+
+    @Nested
+    @DisplayName("Метод getAllCommentsAdmin")
+    class GetAllCommentsAdminServiceTests {
+        private Pageable defaultPageable;
+
+        @BeforeEach
+        void setUpAdminSearch() {
+            defaultPageable = PageRequest.of(0, 10, Sort.by(Sort.Direction.DESC, "createdOn"));
+        }
+
+        @Test
+        @DisplayName("Должен вызывать commentRepository.findAll с предикатом и пагинацией")
+        void getAllCommentsAdmin_withFilters_shouldCallRepositoryWithPredicate() {
+            AdminCommentSearchParams params = AdminCommentSearchParams.builder()
+                .userId(1L)
+                .eventId(2L)
+                .isDeleted(false)
+                .build();
+            Page<Comment> emptyPage = new PageImpl<>(Collections.emptyList(), defaultPageable, 0);
+            when(commentRepository.findAll(any(Predicate.class), eq(defaultPageable))).thenReturn(emptyPage);
+
+            commentService.getAllCommentsAdmin(params, 0, 10);
+
+            verify(commentRepository).findAll(predicateCaptor.capture(), eq(defaultPageable));
+            Predicate capturedPredicate = predicateCaptor.getValue();
+            assertNotNull(capturedPredicate);
+            String predicateStr = capturedPredicate.toString();
+            assertTrue(predicateStr.contains("comment.author.id = 1"));
+            assertTrue(predicateStr.contains("comment.event.id = 2"));
+            assertTrue(predicateStr.contains("comment.isDeleted = false"));
+        }
+
+        @Test
+        @DisplayName("Должен вызывать commentRepository.findAll с пагинацией, если фильтры не заданы")
+        void getAllCommentsAdmin_noFilters_shouldCallRepositoryWithoutPredicateParts() {
+            AdminCommentSearchParams params = AdminCommentSearchParams.builder().build();
+            Page<Comment> emptyPage = new PageImpl<>(Collections.emptyList(), defaultPageable, 0);
+            when(commentRepository.findAll(any(Predicate.class), eq(defaultPageable))).thenReturn(emptyPage);
+
+            commentService.getAllCommentsAdmin(params, 0, 10);
+
+            verify(commentRepository).findAll(predicateCaptor.capture(), eq(defaultPageable));
+            Predicate capturedPredicate = predicateCaptor.getValue();
+            assertNotNull(capturedPredicate);
+        }
+
+        @Test
+        @DisplayName("getAllCommentsAdmin БЕЗ ФИЛЬТРОВ: должен вызывать commentRepository.findAll(Pageable)")
+        void getAllCommentsAdmin_noFiltersAtAll_shouldCallRepositoryFindAllWithPageable() {
+            AdminCommentSearchParams params = AdminCommentSearchParams.builder().build();
+            Page<Comment> emptyPage = new PageImpl<>(Collections.emptyList(), defaultPageable, 0);
+
+            when(commentRepository.findAll(any(Predicate.class), eq(defaultPageable))).thenReturn(emptyPage);
+
+            commentService.getAllCommentsAdmin(params, 0, 10);
+
+            verify(commentRepository, times(1)).findAll(predicateCaptor.capture(), eq(defaultPageable));
+            Predicate capturedPredicate = predicateCaptor.getValue();
+            assertEquals(new BooleanBuilder(), capturedPredicate); // Проверяем, что предикат был пустым.
+        }
+
+
+        @Test
+        @DisplayName("Должен возвращать пустой список, если репозиторий вернул пустую страницу")
+        void getAllCommentsAdmin_whenRepositoryReturnsEmptyPage_shouldReturnEmptyList() {
+            AdminCommentSearchParams params = AdminCommentSearchParams.builder().userId(1L).build();
+            Page<Comment> emptyPage = new PageImpl<>(Collections.emptyList(), defaultPageable, 0);
+            when(commentRepository.findAll(any(Predicate.class), eq(defaultPageable))).thenReturn(emptyPage);
+
+            List<CommentDto> result = commentService.getAllCommentsAdmin(params, 0, 10);
+
+            assertTrue(result.isEmpty());
         }
     }
 }

--- a/main-service/src/test/java/ru/practicum/explorewithme/main/service/CommentServiceImplTest.java
+++ b/main-service/src/test/java/ru/practicum/explorewithme/main/service/CommentServiceImplTest.java
@@ -555,6 +555,7 @@ class CommentServiceImplTest {
 
             List<CommentDto> result = commentService.getAllCommentsAdmin(params, 0, 10);
 
+            verify(commentMapper, times(1)).toDtoList(Collections.emptyList());
             assertTrue(result.isEmpty());
         }
     }

--- a/main-service/src/test/java/ru/practicum/explorewithme/main/service/CommentServiceImplTest.java
+++ b/main-service/src/test/java/ru/practicum/explorewithme/main/service/CommentServiceImplTest.java
@@ -2,11 +2,13 @@ package ru.practicum.explorewithme.main.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -64,9 +66,8 @@ class CommentServiceImplTest {
     @InjectMocks
     private CommentServiceImpl commentService;
 
-    // пока не нужен, но пригодится для тестов Лериных методов
     @Captor
-    private ArgumentCaptor<Comment> commentArgumentCaptor;
+    private ArgumentCaptor<Comment> commentCaptor;
     @Captor
     private ArgumentCaptor<Predicate> predicateCaptor;
 
@@ -305,9 +306,6 @@ class CommentServiceImplTest {
         }
     }
 
-/*
-    тесты для методов из Лериного PR
-
     @Nested
     @DisplayName("Метод deleteCommentByAdmin")
     class DeleteCommentByAdminTests {
@@ -363,7 +361,7 @@ class CommentServiceImplTest {
     @DisplayName("Метод deleteUserComment")
     class DeleteUserCommentTests {
         private Comment userComment;
-        private Long nonAuthorUserId = 999L;
+        private final Long nonAuthorUserId = 999L;
 
         @BeforeEach
         void setUpDeleteUser() {
@@ -392,10 +390,9 @@ class CommentServiceImplTest {
         void deleteUserComment_whenUserIsNotAuthor_shouldThrowException() {
             when(commentRepository.findById(commentId)).thenReturn(Optional.of(userComment));
 
-            EntityNotFoundException ex = assertThrows(EntityNotFoundException.class, () -> {
-                commentService.deleteUserComment(nonAuthorUserId, commentId);
-            });
-            assertTrue(ex.getMessage().contains("is not the author"));
+            EntityNotFoundException ex = assertThrows(EntityNotFoundException.class,
+                () -> commentService.deleteUserComment(nonAuthorUserId, commentId));
+            assertTrue(ex.getMessage().contains("not found for user"));
 
             verify(commentRepository).findById(commentId);
             verify(commentRepository, never()).save(any(Comment.class));
@@ -491,8 +488,6 @@ class CommentServiceImplTest {
             assertTrue(ex.getMessage().contains("Comment with id=" + commentId + " not found"));
         }
     }
-
- */
 
     @Nested
     @DisplayName("Метод getAllCommentsAdmin")

--- a/main-service/src/test/java/ru/practicum/explorewithme/main/service/CommentServiceIntegrationTest.java
+++ b/main-service/src/test/java/ru/practicum/explorewithme/main/service/CommentServiceIntegrationTest.java
@@ -1,5 +1,12 @@
 package ru.practicum.explorewithme.main.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -14,21 +21,18 @@ import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import ru.practicum.explorewithme.main.dto.CommentDto;
 import ru.practicum.explorewithme.main.error.EntityNotFoundException;
-import ru.practicum.explorewithme.main.model.*;
+import ru.practicum.explorewithme.main.model.Category;
+import ru.practicum.explorewithme.main.model.Comment;
+import ru.practicum.explorewithme.main.model.Event;
+import ru.practicum.explorewithme.main.model.EventState;
+import ru.practicum.explorewithme.main.model.Location;
+import ru.practicum.explorewithme.main.model.User;
+import ru.practicum.explorewithme.main.repository.CategoryRepository;
 import ru.practicum.explorewithme.main.repository.CommentRepository;
 import ru.practicum.explorewithme.main.repository.EventRepository;
-import ru.practicum.explorewithme.main.service.params.PublicCommentParameters;
-import ru.practicum.explorewithme.main.repository.CategoryRepository;
 import ru.practicum.explorewithme.main.repository.UserRepository;
-
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
-import java.util.List;
-import java.util.UUID;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static ru.practicum.explorewithme.common.constants.DateTimeConstants.DATE_TIME_FORMAT_PATTERN;
+import ru.practicum.explorewithme.main.service.params.AdminCommentSearchParams;
+import ru.practicum.explorewithme.main.service.params.PublicCommentParameters;
 
 @SpringBootTest
 @Testcontainers
@@ -60,20 +64,48 @@ class CommentServiceIntegrationTest {
     @Autowired
     private UserRepository userRepository;
 
+    private Event event1, event2;
+    private Comment comment1User1Event1, comment2User2Event1, comment3User1Event1Deleted, comment4User2Event2;
+    private LocalDateTime now;
+    private User user1, user2;
+    private Category category1, category2;
+
+    @BeforeEach
+    void setUpEntities() {
+        now = LocalDateTime.now();
+
+        user1 = userRepository.save(
+            User.builder().name("User One").email("user1@example.com").build());
+        user2 = userRepository.save(
+            User.builder().name("User Two").email("user2@example.com").build());
+        category1 = categoryRepository.save(Category.builder().name("Первая категория").build());
+        category2 = categoryRepository.save(Category.builder().name("Вторая категория").build());
+        event1 = saveEvent(true, EventState.PUBLISHED, "Первое событие", user1,
+            category1, now.plusDays(1));
+        event2 = saveEvent(true, EventState.PUBLISHED, "Второе событие", user2,
+            category2, now.plusDays(2));
+
+        comment1User1Event1 = saveComment(event1, user1,
+            "Первый комментарий", now.minusHours(3), false, false);
+        comment2User2Event1 = saveComment(event1, user2,
+            "Второй комментарий", now.minusHours(1), false, false);
+        comment3User1Event1Deleted = saveComment(event1, user1,
+            "Третий комментарий", now.minusHours(2), true,
+            true);
+        comment4User2Event2 = saveComment(event2, user2,
+            "Четвёртый комментарий", now.plusSeconds(1), false,
+            false);
+    }
+
     @Nested
-    @DisplayName("Получение комментариев к событию")
+    @DisplayName("Метод getCommentsForEvent")
     class GetCommentsForEvent {
 
         @Test
         @DisplayName("Возвращает комментарии опубликованного события с включёнными комментариями")
         void shouldReturnComments_whenEventPublishedAndCommentsEnabled() {
 
-            Event event = saveEvent(true, EventState.PUBLISHED);
-            saveComment(event, "Первый комментарий",
-                    LocalDateTime.parse("2025-01-01 10:00:00", DateTimeFormatter.ofPattern(DATE_TIME_FORMAT_PATTERN)));
-            saveComment(event, "Второй комментарий",
-                    LocalDateTime.parse("2025-01-02 10:00:00", DateTimeFormatter.ofPattern(DATE_TIME_FORMAT_PATTERN)));
-
+            Event event = event1;
 
             PublicCommentParameters params = PublicCommentParameters.builder()
                     .from(0)
@@ -81,9 +113,7 @@ class CommentServiceIntegrationTest {
                     .sort(Sort.by(Sort.Direction.DESC, "createdOn"))
                     .build();
 
-
             List<CommentDto> result = commentService.getCommentsForEvent(event.getId(), params);
-
 
             assertThat(result)
                     .hasSize(2)
@@ -95,8 +125,9 @@ class CommentServiceIntegrationTest {
         @DisplayName("Возвращает пустой список, если комментарии отключены")
         void shouldReturnEmptyList_whenCommentsDisabled() {
 
-            Event event = saveEvent(false, EventState.PUBLISHED);
-            saveComment(event, "Отключённый комментарий", LocalDateTime.now());
+            Event event = saveEvent(false, EventState.PUBLISHED,
+                "Событие с отключёнными комментариями", user2, category2, now.plusDays(11));
+            saveComment(event2, user1, "Отключённый комментарий", now, false, false);
 
             PublicCommentParameters params = PublicCommentParameters.builder()
                     .from(0)
@@ -113,7 +144,8 @@ class CommentServiceIntegrationTest {
         @DisplayName("Бросает EntityNotFoundException, когда событие не опубликовано")
         void shouldThrowException_whenEventNotPublished() {
 
-            Event event = saveEvent(true, EventState.CANCELED);
+            Event event = saveEvent(true, EventState.CANCELED, "Отменённое событие", user1,
+                category1, now.plusDays(12));
 
             PublicCommentParameters params = PublicCommentParameters.builder()
                     .from(0)
@@ -129,10 +161,9 @@ class CommentServiceIntegrationTest {
         @DisplayName("Корректная пагинация")
         void shouldApplyPagination() {
 
-            Event event = saveEvent(true, EventState.PUBLISHED);
-            for (int i = 0; i < 5; i++) {
-                saveComment(event, "Комментарий " + i,
-                        LocalDateTime.now().plusSeconds(i));
+            Event event = event1;
+            for (int i = 0; i < 3; i++) { // Добавляем ещё 3 комментария к 2 уже существующим.
+                saveComment(event, user1, "Комментарий " + i, LocalDateTime.now().plusSeconds(i), false, false);
             }
 
             PublicCommentParameters params = PublicCommentParameters.builder()
@@ -157,7 +188,8 @@ class CommentServiceIntegrationTest {
         @Test
         @DisplayName("Пустой список, когда у опубликованного события нет комментариев")
         void shouldReturnEmptyList_whenNoComments() {
-            Event event = saveEvent(true, EventState.PUBLISHED);   // комментарии включены, но мы их не создаём
+            Event event = saveEvent(true, EventState.PUBLISHED, "Событие без комментариев", user1, category2,
+                now.plusDays(12));   // комментарии включены, но мы их не создаём
 
             PublicCommentParameters params = PublicCommentParameters.builder()
                     .from(0).size(10).sort(Sort.unsorted()).build();
@@ -170,7 +202,7 @@ class CommentServiceIntegrationTest {
         @Test
         @DisplayName("Комментарий, помеченный как удалённый, не возвращается")
         void shouldIgnoreDeletedComments() {
-            Event event = saveEvent(true, EventState.PUBLISHED);
+            Event event = event2;
 
             Comment deletedComment = Comment.builder()
                     .event(event)
@@ -190,7 +222,7 @@ class CommentServiceIntegrationTest {
 
             List<CommentDto> result = commentService.getCommentsForEvent(event.getId(), params);
 
-            assertThat(result).isEmpty();
+            assertThat(result).size().isEqualTo(1); // Новый комментарий не добавился
         }
 
         @Test
@@ -205,55 +237,220 @@ class CommentServiceIntegrationTest {
 
     }
 
-    /* ---------- Вспомогательные методы ---------- */
-    private Event saveEvent(boolean commentsEnabled, EventState state) {
+    @Nested
+    @DisplayName("Метод getAllCommentsAdmin")
+    class GetAllCommentsAdminIntegrationTests {
 
+        @Test
+        @DisplayName("Должен возвращать все комментарии (включая удаленные), если фильтры не указаны, с пагинацией")
+        void getAllCommentsAdmin_noFilters_shouldReturnAllCommentsPaged() {
+            AdminCommentSearchParams params = AdminCommentSearchParams.builder().build();
 
-        Category category = categoryRepository.save(
-                Category.builder()
-                        .name("Тестовая категория")
-                        .build());
+            List<CommentDto> resultsPage1 = commentService.getAllCommentsAdmin(params, 0, 2);
+            List<CommentDto> resultsPage2 = commentService.getAllCommentsAdmin(params, 2, 2);
 
-        User initiator = userRepository.save(
-                User.builder()
-                        .name("Инициатор")
-                        .email("initiator@example.com")
-                        .build());
+            assertAll(
+                () -> assertThat(resultsPage1)
+                    .as("Страница 1: проверка количества комментариев")
+                    .hasSize(2),
+                () -> assertThat(resultsPage1.get(0))
+                    .as("Страница 1, Комментарий 1: должен быть comment4User2Event2 (ID и Текст)")
+                    .hasFieldOrPropertyWithValue("id", comment4User2Event2.getId())
+                    .hasFieldOrPropertyWithValue("text", comment4User2Event2.getText()),
+                () -> assertThat(resultsPage1.get(1))
+                    .as("Страница 1, Комментарий 2: должен быть comment3User1Event1Deleted (ID и Текст)")
+                    .hasFieldOrPropertyWithValue("id", comment3User1Event1Deleted.getId())
+                    .hasFieldOrPropertyWithValue("text", comment3User1Event1Deleted.getText()),
 
-        Event event = Event.builder()
-                .title("Событие")
-                .annotation("Краткое описание события")
-                .description("Описание")
-                .state(state)
-                .commentsEnabled(commentsEnabled)
-                .category(category)
-                .initiator(initiator)
-                .eventDate(LocalDateTime.now().plusDays(1))
-                .location(new Location(55.7522F, 37.6156F))
-                .paid(false)
-                .participantLimit(0)
-                .requestModeration(false)
+                () -> assertThat(resultsPage2)
+                    .as("Страница 2: проверка количества комментариев")
+                    .hasSize(2),
+                () -> assertThat(resultsPage2.get(0))
+                    .as("Страница 2, Комментарий 1: должен быть comment2User2Event1 (ID и Текст)")
+                    .hasFieldOrPropertyWithValue("id", comment2User2Event1.getId())
+                    .hasFieldOrPropertyWithValue("text", comment2User2Event1.getText()),
+                () -> assertThat(resultsPage2.get(1))
+                    .as("Страница 2, Комментарий 2: должен быть comment1User1Event1 (ID и Текст)")
+                    .hasFieldOrPropertyWithValue("id", comment1User1Event1.getId())
+                    .hasFieldOrPropertyWithValue("text", comment1User1Event1.getText())
+            );
+        }
+
+        @Test
+        @DisplayName("Должен фильтровать по userId")
+        void getAllCommentsAdmin_withUserIdFilter_shouldReturnUserComments() {
+            AdminCommentSearchParams params = AdminCommentSearchParams.builder()
+                .userId(user1.getId()).build();
+            List<CommentDto> results = commentService.getAllCommentsAdmin(params, 0, 10);
+
+            assertAll(
+                () -> assertThat(results)
+                    .as("Должен вернуть 2 комментария для user1")
+                    .hasSize(2),
+                () -> assertThat(results)
+                    .as("Все возвращенные комментарии должны принадлежать user1")
+                    .allSatisfy(commentDto ->
+                        assertThat(commentDto.getAuthor().getId())
+                            .isEqualTo(user1.getId())),
+                () -> assertThat(results)
+                    .as("Комментарий 1 для user1 (ID: %s) должен присутствовать", comment1User1Event1.getId())
+                    .extracting(CommentDto::getId) // Extracts all IDs from the list of CommentDto
+                    .contains(comment1User1Event1.getId()),
+                () -> assertThat(results)
+                    .as("Комментарий 2 для user1 (удален) (ID: %s) должен присутствовать", comment3User1Event1Deleted.getId())
+                    .extracting(CommentDto::getId) // Extracts all IDs from the list of CommentDto
+                    .contains(comment3User1Event1Deleted.getId())
+            );
+        }
+
+        @Test
+        @DisplayName("Должен фильтровать по eventId")
+        void getAllCommentsAdmin_withEventIdFilter_shouldReturnEventComments() {
+            AdminCommentSearchParams params = AdminCommentSearchParams.builder()
+                .eventId(event1.getId()).build();
+            List<CommentDto> results = commentService.getAllCommentsAdmin(params, 0, 10);
+
+            assertAll(
+                () -> assertThat(results)
+                    .as("Должен вернуть 3 комментария для event1")
+                    .hasSize(3),
+                () -> assertThat(results)
+                    .as("Все возвращенные комментарии должны принадлежать event1 (ID: %s)", event1.getId())
+                    .allSatisfy(commentDto ->
+                        assertThat(commentDto.getEventId())
+                            .isEqualTo(event1.getId()))
+            );
+        }
+
+        @Test
+        @DisplayName("Должен фильтровать по isDeleted = false (только не удаленные)")
+        void getAllCommentsAdmin_withIsDeletedFalse_shouldReturnNotDeletedComments() {
+            AdminCommentSearchParams params = AdminCommentSearchParams.builder().isDeleted(false)
                 .build();
+            List<CommentDto> results = commentService.getAllCommentsAdmin(params, 0, 10);
 
-        return eventRepository.save(event);
+            assertAll(
+                () -> assertThat(results)
+                    .as("Должен вернуть 3 неудаленных комментария")
+                    .hasSize(3),
+                () -> assertThat(results)
+                    .as("Удаленный комментарий (comment2 ID: %s) НЕ должен присутствовать в результатах", comment3User1Event1Deleted.getId())
+                    .extracting(CommentDto::getId) // Extract IDs from the DTOs
+                    .doesNotContain(comment3User1Event1Deleted.getId()),
+                () -> assertThat(results)
+                    .as("Комментарий1 (ID: %s) должен присутствовать в результатах", comment1User1Event1.getId())
+                    .extracting(CommentDto::getId)
+                    .contains(comment1User1Event1.getId()),
+                () -> assertThat(results)
+                    .as("Комментарий3 (ID: %s) должен присутствовать в результатах", comment2User2Event1.getId())
+                    .extracting(CommentDto::getId)
+                    .contains(comment2User2Event1.getId()),
+                () -> assertThat(results)
+                    .as("Комментарий4 (ID: %s) должен присутствовать в результатах", comment4User2Event2.getId())
+                    .extracting(CommentDto::getId)
+                    .contains(comment4User2Event2.getId()),
+                () -> assertThat(results)
+                    .as("Все полученные экземпляры CommentDto должны иметь ненулевой ID типа Long")
+                    .allSatisfy(dto -> assertThat(dto.getId())
+                        .as("ID для DTO с текстом '%s'", dto.getText())
+                        .isNotNull()
+                        .isInstanceOf(Long.class))
+            );
+
+            results.forEach(commentDto ->
+                assertThat(findCommentInDb(commentDto.getId()).isDeleted())
+                    .as("Комментарий %s (проверка БД) не должен быть помечен как удаленный", commentDto.getId())
+                    .isFalse()
+            );
+        }
+
+        @Test
+        @DisplayName("Должен фильтровать по isDeleted = true (только удаленные)")
+        void getAllCommentsAdmin_withIsDeletedTrue_shouldReturnDeletedComments() {
+            AdminCommentSearchParams params = AdminCommentSearchParams.builder().isDeleted(true)
+                .build();
+            List<CommentDto> results = commentService.getAllCommentsAdmin(params, 0, 10);
+
+            assertAll(
+                () -> assertThat(results)
+                    .as("Должен вернуть ровно 1 удаленный комментарий")
+                    .hasSize(1),
+                () -> assertThat(results.getFirst())
+                    .as("Возвращенный комментарий должен быть comment2User1Event1Deleted (ID: %s)", comment3User1Event1Deleted.getId())
+                    .hasFieldOrPropertyWithValue("id", comment3User1Event1Deleted.getId())
+            );
+
+            CommentDto resultDto = results.getFirst();
+            assertThat(findCommentInDb(resultDto.getId()).isDeleted())
+                .as("Комментарий %s (проверка БД) должен быть помечен как удаленный", resultDto.getId())
+                .isTrue();
+        }
+
+        @Test
+        @DisplayName("Должен корректно работать с комбинацией фильтров (userId, eventId, isDeleted=false)")
+        void getAllCommentsAdmin_withCombinedFilters_shouldReturnMatchingComments() {
+            AdminCommentSearchParams params = AdminCommentSearchParams.builder()
+                .userId(user1.getId()).eventId(event1.getId()).isDeleted(false).build();
+            List<CommentDto> results = commentService.getAllCommentsAdmin(params, 0, 10);
+
+            assertAll(
+                () -> assertThat(results)
+                    .as("Должен вернуть ровно 1 комментарий по заданным фильтрам")
+                    .hasSize(1),
+                () -> {
+                    CommentDto resultDto = results.getFirst();
+                    assertThat(resultDto)
+                        .as("Возвращенный комментарий (ID: %s) должен соответствовать comment1User1Event1", resultDto.getId())
+                        .hasFieldOrPropertyWithValue("id", comment1User1Event1.getId())
+                        .hasFieldOrPropertyWithValue("text", comment1User1Event1.getText())
+                        .hasFieldOrPropertyWithValue("eventId", event1.getId());
+                    assertThat(resultDto)
+                        .as("Автор возвращенного комментария (ID: %s) должен быть user1 (ID: %s)", resultDto.getId(), user1.getId())
+                        .hasFieldOrPropertyWithValue("author.id", user1.getId());
+                }
+            );
+
+            CommentDto resultDtoForDbCheck = results.getFirst();
+            assertThat(findCommentInDb(resultDtoForDbCheck.getId()).isDeleted())
+                .as("Комментарий %s (проверка БД) не должен быть помечен как удаленный", resultDtoForDbCheck.getId())
+                .isFalse();
+        }
+
+        @Test
+        @DisplayName("Должен возвращать пустой список, если по фильтрам ничего не найдено")
+        void getAllCommentsAdmin_whenNoMatch_shouldReturnEmptyList() {
+            AdminCommentSearchParams params = AdminCommentSearchParams.builder().userId(999L)
+                .build();
+            List<CommentDto> results = commentService.getAllCommentsAdmin(params, 0, 10);
+
+            assertThat(results).isEmpty();
+        }
     }
 
-    private void saveComment(Event event, String text, LocalDateTime createdOn) {
+    /* ---------- Вспомогательные методы ---------- */
 
-        User author = userRepository.save(
-                User.builder()
-                        .name("Автор")
-                        .email("author_" + UUID.randomUUID() + "@example.com")
-                        .build());
+    private Comment saveComment(Event event, User author, String text,
+        LocalDateTime createdOn, boolean isEdited, boolean isDeleted) {
+        Comment comment = Comment.builder().event(event).author(author).text(text)
+            .createdOn(createdOn)
+            .isEdited(isEdited).isDeleted(isDeleted).build();
+        return commentRepository.saveAndFlush(
+            comment);
+    }
 
-        Comment comment = Comment.builder()
-                .event(event)
-                .author(author)            // ← задаём автора
-                .text(text)
-                .createdOn(createdOn)
-                .isDeleted(false)
-                .build();
+    private Event saveEvent(boolean commentsEnabled, EventState state, String title,
+        User initiator, Category category, LocalDateTime eventDate) {
+        Event event = Event.builder().title(title).annotation("Annotation for " + title)
+            .description("Description for " + title).state(state)
+            .commentsEnabled(commentsEnabled).category(category).initiator(initiator)
+            .eventDate(eventDate).location(new Location(55.75f, 37.61f))
+            .paid(false).participantLimit(0).requestModeration(true)
+            .build();
+        return eventRepository.saveAndFlush(event);
+    }
 
-        commentRepository.save(comment);
+    private Comment findCommentInDb(Long commentId) {
+        return commentRepository.findById(commentId).orElseThrow(() -> new AssertionError(
+            "Комментарий не найден в БД для проверки тестом: " + commentId));
     }
 }

--- a/main-service/src/test/java/ru/practicum/explorewithme/main/service/CommentServiceIntegrationTest.java
+++ b/main-service/src/test/java/ru/practicum/explorewithme/main/service/CommentServiceIntegrationTest.java
@@ -294,11 +294,11 @@ class CommentServiceIntegrationTest {
                             .isEqualTo(user1.getId())),
                 () -> assertThat(results)
                     .as("Комментарий 1 для user1 (ID: %s) должен присутствовать", comment1User1Event1.getId())
-                    .extracting(CommentDto::getId) // Extracts all IDs from the list of CommentDto
+                    .extracting(CommentDto::getId)
                     .contains(comment1User1Event1.getId()),
                 () -> assertThat(results)
                     .as("Комментарий 2 для user1 (удален) (ID: %s) должен присутствовать", comment3User1Event1Deleted.getId())
-                    .extracting(CommentDto::getId) // Extracts all IDs from the list of CommentDto
+                    .extracting(CommentDto::getId)
                     .contains(comment3User1Event1Deleted.getId())
             );
         }
@@ -335,7 +335,7 @@ class CommentServiceIntegrationTest {
                     .hasSize(3),
                 () -> assertThat(results)
                     .as("Удаленный комментарий (comment2 ID: %s) НЕ должен присутствовать в результатах", comment3User1Event1Deleted.getId())
-                    .extracting(CommentDto::getId) // Extract IDs from the DTOs
+                    .extracting(CommentDto::getId)
                     .doesNotContain(comment3User1Event1Deleted.getId()),
                 () -> assertThat(results)
                     .as("Комментарий1 (ID: %s) должен присутствовать в результатах", comment1User1Event1.getId())


### PR DESCRIPTION
## Описание

Данный Pull Request реализует эндпоинт для администраторов (`GET /admin/comments`), позволяющий получать список всех комментариев с возможностью фильтрации и пагинации.

### Ключевые изменения:

1.  **Репозиторий (`CommentRepository`):**
    *   Интерфейс `CommentRepository` теперь расширяет `QuerydslPredicateExecutor<Comment>` для поддержки динамических запросов.
    *   Добавлена аннотация `@EntityGraph(attributePaths = {"author"})` к методу `findAll(Predicate, Pageable)` для решения проблемы N+1 при загрузке авторов комментариев.

2.  **Сервисный слой (`CommentServiceImpl`):**
    *   Реализован метод `getAllCommentsAdmin(AdminCommentSearchParams searchParams, int from, int size)`.
    *   Используется QueryDSL (`BooleanBuilder`, `QComment`) для динамического построения предиката на основе параметров фильтрации: `userId` (автор), `eventId` (событие), `isDeleted` (статус удаления).
    *   Применяется пагинация и сортировка по умолчанию (по `createdOn DESC`).
    *   Результат маппится в `List<CommentDto>` с использованием `CommentMapper`.

3.  **DTO для параметров поиска:**
    *   Создан класс `AdminCommentSearchParams` для инкапсуляции параметров фильтрации.

4.  **Контроллер (`AdminCommentController`):**
    *   Реализован эндпоинт `GET /admin/comments`.
    *   Принимает опциональные query-параметры `userId`, `eventId`, `isDeleted` и параметры пагинации `from`, `size`.
    *   Передает параметры в сервисный слой через `AdminCommentSearchParams`.

5.  **Тестирование:**
    *   Добавлены юнит-тесты для `CommentServiceImpl` (проверка логики построения предиката QueryDSL и вызова репозитория).
    *   Добавлены юнит-тесты для `AdminCommentController` (`@WebMvcTest`), проверяющие маппинг запроса, передачу параметров в сервис и обработку ответов.
    *   Добавлены/обновлены интеграционные тесты для `CommentServiceImpl` (`@SpringBootTest` с Testcontainers), проверяющие корректность фильтрации QueryDSL на реальной базе данных.

### Примечания:
*   Логика обработки параметра `isDeleted` в сервисе: если параметр не передан (`null`), фильтр по `isDeleted` не применяется (возвращаются и удаленные, и не удаленные комментарии). Если передан `true` или `false`, происходит соответствующая фильтрация.