### PR TITLE
FIX: Корректное обновление updatedOn для Comment при редактировании

### DIFF
--- a/main-service/src/main/java/ru/practicum/explorewithme/main/service/CommentServiceImpl.java
+++ b/main-service/src/main/java/ru/practicum/explorewithme/main/service/CommentServiceImpl.java
@@ -111,7 +111,7 @@ public class CommentServiceImpl implements CommentService {
             throw new EntityNotFoundException("Искомый комментарий с id " + commentId + " пользователя с id " + userId + "не найден");
         }
 
-        if (existedComment.isDeleted() == true) {
+        if (existedComment.isDeleted()) {
             throw new BusinessRuleViolationException("Редактирование невозможно. Комментарий удален");
         }
 

--- a/main-service/src/main/java/ru/practicum/explorewithme/main/service/CommentServiceImpl.java
+++ b/main-service/src/main/java/ru/practicum/explorewithme/main/service/CommentServiceImpl.java
@@ -122,6 +122,6 @@ public class CommentServiceImpl implements CommentService {
         existedComment.setText(updateCommentDto.getText());
         existedComment.setEdited(true);
 
-        return commentMapper.toDto(commentRepository.save(existedComment));
+        return commentMapper.toDto(commentRepository.saveAndFlush(existedComment));
     }
 }


### PR DESCRIPTION
## Описание

Данный Pull Request исправляет ошибку, при которой поле `updatedOn` в сущности `Comment` не обновлялось корректно при редактировании, если изменения не были немедленно синхронизированы с базой данных перед возвратом сущности из сервисного метода.

### Проблема:
Механизм JPA Auditing (`@LastModifiedDate`) обновляет поле `updatedOn` во время операции `flush`. Если `flush` не вызывался явно после изменения сущности `Comment` и перед ее маппингом в DTO, возвращаемый DTO мог содержать `updatedOn`, равный `createdOn`.

### Реализованные изменения:
*   В методе `CommentServiceImpl.updateUserComment` вызов `commentRepository.save(existedComment)` заменен на `commentRepository.saveAndFlush(existedComment)`.
*   Это гарантирует, что `AuditingEntityListener` обновит поле `updatedOn` до того, как измененная сущность будет использована для формирования ответа DTO.