### PR TITLE
Comments Admin API: CommentAdminDto с флагом isDeleted

### DIFF
--- a/main-service/src/main/java/ru/practicum/explorewithme/main/controller/admin/AdminCommentController.java
+++ b/main-service/src/main/java/ru/practicum/explorewithme/main/controller/admin/AdminCommentController.java
@@ -15,7 +15,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
-import ru.practicum.explorewithme.main.dto.CommentDto;
+import ru.practicum.explorewithme.main.dto.CommentAdminDto;
 import ru.practicum.explorewithme.main.service.CommentService;
 import ru.practicum.explorewithme.main.service.params.AdminCommentSearchParams;
 
@@ -38,9 +38,9 @@ public class AdminCommentController {
 
     @PatchMapping("/{commentId}/restore")
     @ResponseStatus(HttpStatus.OK)
-    public CommentDto restoreComment(@PathVariable @Positive Long commentId) {
+    public CommentAdminDto restoreComment(@PathVariable @Positive Long commentId) {
         log.info("Admin: Received request to restore comment with Id: {}", commentId);
-        CommentDto restoredComment = commentService.restoreCommentByAdmin(commentId);
+        CommentAdminDto restoredComment = commentService.restoreCommentByAdmin(commentId);
         log.info("Admin: Comment with Id: {} restored", commentId);
         return restoredComment;
     }
@@ -57,7 +57,7 @@ public class AdminCommentController {
      */
     @GetMapping
     @ResponseStatus(HttpStatus.OK)
-    public List<CommentDto> getAllCommentsAdmin(
+    public List<CommentAdminDto> getAllCommentsAdmin(
         @RequestParam(name = "userId", required = false) @Positive Long userId,
         @RequestParam(name = "eventId", required = false) @Positive Long eventId,
         @RequestParam(name = "isDeleted", required = false) Boolean isDeleted,
@@ -73,7 +73,7 @@ public class AdminCommentController {
             .isDeleted(isDeleted)
             .build();
 
-        List<CommentDto> comments = commentService.getAllCommentsAdmin(searchParams, from, size);
+        List<CommentAdminDto> comments = commentService.getAllCommentsAdmin(searchParams, from, size);
 
         log.info("Admin: Found {} comments matching criteria.", comments.size());
         return comments;

--- a/main-service/src/main/java/ru/practicum/explorewithme/main/dto/CommentAdminDto.java
+++ b/main-service/src/main/java/ru/practicum/explorewithme/main/dto/CommentAdminDto.java
@@ -1,0 +1,38 @@
+package ru.practicum.explorewithme.main.dto;
+
+import static ru.practicum.explorewithme.common.constants.DateTimeConstants.DATE_TIME_FORMAT_PATTERN;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.experimental.FieldDefaults;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@FieldDefaults(level = AccessLevel.PRIVATE)
+public class CommentAdminDto {
+
+    Long id;
+
+    String text;
+
+    UserShortDto author;
+
+    Long eventId;
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = DATE_TIME_FORMAT_PATTERN)
+    LocalDateTime createdOn;
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = DATE_TIME_FORMAT_PATTERN)
+    LocalDateTime updatedOn;
+
+    Boolean isEdited;
+
+    Boolean isDeleted;
+}

--- a/main-service/src/main/java/ru/practicum/explorewithme/main/mapper/CommentMapper.java
+++ b/main-service/src/main/java/ru/practicum/explorewithme/main/mapper/CommentMapper.java
@@ -3,6 +3,7 @@ package ru.practicum.explorewithme.main.mapper;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.Mappings;
+import ru.practicum.explorewithme.main.dto.CommentAdminDto; // <<< Новый импорт
 import ru.practicum.explorewithme.main.dto.CommentDto;
 import ru.practicum.explorewithme.main.dto.NewCommentDto;
 import ru.practicum.explorewithme.main.model.Comment;
@@ -30,8 +31,9 @@ public interface CommentMapper {
 
 
     /**
-     * Маппинг из сущности Comment в CommentDto.
+     * Маппинг из сущности Comment в CommentDto (для публичного/пользовательского API).
      * Поле eventId извлекается из comment.getEvent().getId().
+     * Поле isDeleted не включается.
      */
     @Mappings({
         @Mapping(source = "event.id", target = "eventId"),
@@ -40,5 +42,18 @@ public interface CommentMapper {
     CommentDto toDto(Comment comment);
 
     List<CommentDto> toDtoList(List<Comment> comments);
+
+    /**
+     * Маппинг из сущности Comment в CommentAdminDto (для административного API).
+     * Включает поле isDeleted.
+     */
+    @Mappings({
+        @Mapping(source = "event.id", target = "eventId"),
+        @Mapping(source = "edited", target = "isEdited"),
+        @Mapping(source = "deleted", target = "isDeleted")
+    })
+    CommentAdminDto toAdminDto(Comment comment);
+
+    List<CommentAdminDto> toAdminDtoList(List<Comment> comments);
 
 }

--- a/main-service/src/main/java/ru/practicum/explorewithme/main/service/CommentService.java
+++ b/main-service/src/main/java/ru/practicum/explorewithme/main/service/CommentService.java
@@ -1,5 +1,6 @@
 package ru.practicum.explorewithme.main.service;
 
+import ru.practicum.explorewithme.main.dto.CommentAdminDto;
 import ru.practicum.explorewithme.main.dto.CommentDto;
 import ru.practicum.explorewithme.main.dto.NewCommentDto;
 import ru.practicum.explorewithme.main.dto.UpdateCommentDto;
@@ -22,7 +23,7 @@ public interface CommentService {
 
     void deleteUserComment(Long userId, Long commentId);
 
-    CommentDto restoreCommentByAdmin(Long commentId);
+    CommentAdminDto restoreCommentByAdmin(Long commentId);
 
-    List<CommentDto> getAllCommentsAdmin(AdminCommentSearchParams searchParams, int from, int size);
+    List<CommentAdminDto> getAllCommentsAdmin(AdminCommentSearchParams searchParams, int from, int size);
 }

--- a/main-service/src/main/java/ru/practicum/explorewithme/main/service/CommentServiceImpl.java
+++ b/main-service/src/main/java/ru/practicum/explorewithme/main/service/CommentServiceImpl.java
@@ -12,6 +12,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import ru.practicum.explorewithme.main.dto.CommentAdminDto;
 import ru.practicum.explorewithme.main.dto.CommentDto;
 import ru.practicum.explorewithme.main.dto.NewCommentDto;
 import ru.practicum.explorewithme.main.dto.UpdateCommentDto;
@@ -152,19 +153,19 @@ public class CommentServiceImpl implements CommentService {
 
     @Override
     @Transactional
-    public CommentDto restoreCommentByAdmin(Long commentId) {
+    public CommentAdminDto restoreCommentByAdmin(Long commentId) {
         Comment comment = commentRepository.findById(commentId)
                 .orElseThrow(() -> new EntityNotFoundException(String.format("Comment with id=%d not found", commentId)));
         if (comment.isDeleted()) {
             comment.setDeleted(false);
             commentRepository.save(comment);
         }
-        return commentMapper.toDto(comment);
+        return commentMapper.toAdminDto(comment);
     }
 
     @Override
     @Transactional(readOnly = true)
-    public List<CommentDto> getAllCommentsAdmin(AdminCommentSearchParams searchParams, int from, int size) {
+    public List<CommentAdminDto> getAllCommentsAdmin(AdminCommentSearchParams searchParams, int from, int size) {
         log.debug("Admin: Searching all comments with params: {}, from={}, size={}", searchParams, from, size);
 
         QComment qComment = QComment.comment;
@@ -186,7 +187,7 @@ public class CommentServiceImpl implements CommentService {
 
         Page<Comment> commentPage = commentRepository.findAll(predicate, pageable);
 
-        List<CommentDto> result = commentMapper.toDtoList(commentPage.getContent());
+        List<CommentAdminDto> result = commentMapper.toAdminDtoList(commentPage.getContent());
         log.debug("Admin: Found {} comments for the given criteria.", result.size());
         return result;
     }

--- a/main-service/src/test/java/ru/practicum/explorewithme/main/controller/admin/AdminCommentControllerTest.java
+++ b/main-service/src/test/java/ru/practicum/explorewithme/main/controller/admin/AdminCommentControllerTest.java
@@ -18,7 +18,7 @@ import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Nested; // Добавлен импорт Nested
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
@@ -27,7 +27,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
-import ru.practicum.explorewithme.main.dto.CommentDto;
+import ru.practicum.explorewithme.main.dto.CommentAdminDto;
 import ru.practicum.explorewithme.main.dto.UserShortDto;
 import ru.practicum.explorewithme.main.service.CommentService;
 import ru.practicum.explorewithme.main.service.params.AdminCommentSearchParams;
@@ -77,9 +77,9 @@ class AdminCommentControllerTest {
         @DisplayName("Должен вернуть 200 OK и список CommentDto, если комментарии найдены")
         void whenCommentsFound_shouldReturnOkAndDtoList() throws Exception {
             UserShortDto author = UserShortDto.builder().id(1L).name("Test Author").build();
-            CommentDto comment1 = CommentDto.builder().id(1L).text("Comment 1").author(author).eventId(100L).createdOn(LocalDateTime.now()).build();
-            CommentDto comment2 = CommentDto.builder().id(2L).text("Comment 2").author(author).eventId(101L).createdOn(LocalDateTime.now()).build();
-            List<CommentDto> comments = List.of(comment1, comment2);
+            CommentAdminDto comment1 = CommentAdminDto.builder().id(1L).text("Comment 1").author(author).eventId(100L).createdOn(LocalDateTime.now()).build();
+            CommentAdminDto comment2 = CommentAdminDto.builder().id(2L).text("Comment 2").author(author).eventId(101L).createdOn(LocalDateTime.now()).build();
+            List<CommentAdminDto> comments = List.of(comment1, comment2);
 
             when(commentService.getAllCommentsAdmin(any(AdminCommentSearchParams.class), eq(0), eq(10)))
                 .thenReturn(comments);

--- a/main-service/src/test/java/ru/practicum/explorewithme/main/mapper/CommentMapperTest.java
+++ b/main-service/src/test/java/ru/practicum/explorewithme/main/mapper/CommentMapperTest.java
@@ -7,8 +7,10 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
+import ru.practicum.explorewithme.main.dto.CommentAdminDto;
 import ru.practicum.explorewithme.main.dto.CommentDto;
 import ru.practicum.explorewithme.main.dto.NewCommentDto;
+import ru.practicum.explorewithme.main.model.Category;
 import ru.practicum.explorewithme.main.model.Comment;
 import ru.practicum.explorewithme.main.model.Event;
 import ru.practicum.explorewithme.main.model.User;
@@ -202,6 +204,67 @@ class CommentMapperTest {
 
             assertNotNull(dtoList);
             assertTrue(dtoList.isEmpty());
+        }
+    }
+
+    @Nested
+    @DisplayName("Метод toAdminDto (маппинг Comment -> CommentAdminDto)")
+    class ToAdminDtoTests {
+
+        @Test
+        @DisplayName("Должен корректно маппить все поля, включая isDeleted")
+        void toAdminDto_shouldMapAllFieldsIncludingIsDeleted() {
+            User authorModel = User.builder().id(1L).name("Admin Test Author").build();
+            Category categoryModel = Category.builder().id(1L).name("Admin Test Category").build();
+            Event eventModel = Event.builder().id(1L).category(categoryModel).initiator(authorModel).build();
+
+
+            Comment comment = Comment.builder()
+                .id(1L)
+                .text("Admin DTO test comment")
+                .author(authorModel)
+                .event(eventModel)
+                .createdOn(LocalDateTime.now().minusHours(1))
+                .updatedOn(LocalDateTime.now())
+                .isEdited(true)
+                .isDeleted(true)
+                .build();
+
+            CommentAdminDto dto = commentMapper.toAdminDto(comment);
+
+            assertNotNull(dto);
+            assertEquals(comment.getId(), dto.getId());
+            assertEquals(comment.getText(), dto.getText());
+            assertEquals(comment.getCreatedOn(), dto.getCreatedOn());
+            assertEquals(comment.getUpdatedOn(), dto.getUpdatedOn());
+            assertEquals(comment.isEdited(), dto.getIsEdited());
+            assertEquals(comment.isDeleted(), dto.getIsDeleted()); // Проверяем isDeleted
+
+            assertNotNull(dto.getAuthor());
+            assertEquals(authorModel.getId(), dto.getAuthor().getId());
+
+            assertNotNull(dto.getEventId());
+            assertEquals(eventModel.getId(), dto.getEventId());
+        }
+
+        @Test
+        @DisplayName("Должен корректно маппить isDeleted=false")
+        void toAdminDto_withIsDeletedFalse_shouldMapCorrectly() {
+            User authorModel = User.builder().id(1L).name("Admin Test Author").build();
+            Event eventModel = Event.builder().id(1L).build();
+
+            Comment comment = Comment.builder()
+                .id(2L)
+                .text("Not deleted comment")
+                .author(authorModel)
+                .event(eventModel)
+                .isDeleted(false)
+                .build();
+
+            CommentAdminDto dto = commentMapper.toAdminDto(comment);
+
+            assertNotNull(dto);
+            assertEquals(false, dto.getIsDeleted());
         }
     }
 }

--- a/main-service/src/test/java/ru/practicum/explorewithme/main/service/CommentServiceImplTest.java
+++ b/main-service/src/test/java/ru/practicum/explorewithme/main/service/CommentServiceImplTest.java
@@ -36,6 +36,7 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
+import ru.practicum.explorewithme.main.dto.CommentAdminDto;
 import ru.practicum.explorewithme.main.dto.CommentDto;
 import ru.practicum.explorewithme.main.dto.NewCommentDto;
 import ru.practicum.explorewithme.main.dto.UpdateCommentDto;
@@ -426,7 +427,7 @@ class CommentServiceImplTest {
     class RestoreCommentByAdminTests {
         private Comment deletedComment;
         private Comment notDeletedComment;
-        private CommentDto mappedDto;
+        private CommentAdminDto mappedDto;
 
         @BeforeEach
         void setUpRestore() {
@@ -440,7 +441,7 @@ class CommentServiceImplTest {
             notDeletedComment.setDeleted(false);
             notDeletedComment.setText("Another text");
 
-            mappedDto = CommentDto.builder().id(commentId).text("Some text").isEdited(false).build();
+            mappedDto = CommentAdminDto.builder().id(commentId).text("Some text").isEdited(false).build();
         }
 
         @Test
@@ -448,9 +449,9 @@ class CommentServiceImplTest {
         void restoreCommentByAdmin_whenCommentIsDeleted_shouldRestoreAndReturnDto() {
             when(commentRepository.findById(commentId)).thenReturn(Optional.of(deletedComment));
             when(commentRepository.save(any(Comment.class))).thenAnswer(invocation -> invocation.getArgument(0));
-            when(commentMapper.toDto(any(Comment.class))).thenReturn(mappedDto);
+            when(commentMapper.toAdminDto(any(Comment.class))).thenReturn(mappedDto);
 
-            CommentDto result = commentService.restoreCommentByAdmin(commentId);
+            CommentAdminDto result = commentService.restoreCommentByAdmin(commentId);
 
             assertNotNull(result);
             assertEquals(mappedDto.getText(), result.getText());
@@ -458,24 +459,24 @@ class CommentServiceImplTest {
             verify(commentRepository).save(commentCaptor.capture());
             Comment savedComment = commentCaptor.getValue();
             assertFalse(savedComment.isDeleted());
-            verify(commentMapper).toDto(savedComment);
+            verify(commentMapper).toAdminDto(savedComment);
         }
 
         @Test
         @DisplayName("Должен возвращать DTO без изменений, если комментарий не был удален")
         void restoreCommentByAdmin_whenCommentIsNotDeleted_shouldReturnDtoWithoutSaving() {
             when(commentRepository.findById(notDeletedComment.getId())).thenReturn(Optional.of(notDeletedComment));
-            when(commentMapper.toDto(notDeletedComment)).thenReturn(
-                CommentDto.builder().id(notDeletedComment.getId()).text(notDeletedComment.getText()).build()
+            when(commentMapper.toAdminDto(notDeletedComment)).thenReturn(
+                CommentAdminDto.builder().id(notDeletedComment.getId()).text(notDeletedComment.getText()).build()
             );
 
-            CommentDto result = commentService.restoreCommentByAdmin(notDeletedComment.getId());
+            CommentAdminDto result = commentService.restoreCommentByAdmin(notDeletedComment.getId());
 
             assertNotNull(result);
             assertEquals(notDeletedComment.getText(), result.getText());
             verify(commentRepository).findById(notDeletedComment.getId());
             verify(commentRepository, never()).save(any(Comment.class));
-            verify(commentMapper).toDto(notDeletedComment);
+            verify(commentMapper).toAdminDto(notDeletedComment);
         }
 
         @Test
@@ -558,9 +559,9 @@ class CommentServiceImplTest {
             Page<Comment> emptyPage = new PageImpl<>(Collections.emptyList(), defaultPageable, 0);
             when(commentRepository.findAll(any(Predicate.class), eq(defaultPageable))).thenReturn(emptyPage);
 
-            List<CommentDto> result = commentService.getAllCommentsAdmin(params, 0, 10);
+            List<CommentAdminDto> result = commentService.getAllCommentsAdmin(params, 0, 10);
 
-            verify(commentMapper, times(1)).toDtoList(Collections.emptyList());
+            verify(commentMapper, times(1)).toAdminDtoList(Collections.emptyList());
             assertTrue(result.isEmpty());
         }
     }

--- a/main-service/src/test/java/ru/practicum/explorewithme/main/service/CommentServiceIntegrationTest.java
+++ b/main-service/src/test/java/ru/practicum/explorewithme/main/service/CommentServiceIntegrationTest.java
@@ -19,6 +19,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
+import ru.practicum.explorewithme.main.dto.CommentAdminDto;
 import ru.practicum.explorewithme.main.dto.CommentDto;
 import ru.practicum.explorewithme.main.error.EntityNotFoundException;
 import ru.practicum.explorewithme.main.model.Category;
@@ -246,8 +247,8 @@ class CommentServiceIntegrationTest {
         void getAllCommentsAdmin_noFilters_shouldReturnAllCommentsPaged() {
             AdminCommentSearchParams params = AdminCommentSearchParams.builder().build();
 
-            List<CommentDto> resultsPage1 = commentService.getAllCommentsAdmin(params, 0, 2);
-            List<CommentDto> resultsPage2 = commentService.getAllCommentsAdmin(params, 2, 2);
+            List<CommentAdminDto> resultsPage1 = commentService.getAllCommentsAdmin(params, 0, 2);
+            List<CommentAdminDto> resultsPage2 = commentService.getAllCommentsAdmin(params, 2, 2);
 
             assertAll(
                 () -> assertThat(resultsPage1)
@@ -281,7 +282,7 @@ class CommentServiceIntegrationTest {
         void getAllCommentsAdmin_withUserIdFilter_shouldReturnUserComments() {
             AdminCommentSearchParams params = AdminCommentSearchParams.builder()
                 .userId(user1.getId()).build();
-            List<CommentDto> results = commentService.getAllCommentsAdmin(params, 0, 10);
+            List<CommentAdminDto> results = commentService.getAllCommentsAdmin(params, 0, 10);
 
             assertAll(
                 () -> assertThat(results)
@@ -294,11 +295,11 @@ class CommentServiceIntegrationTest {
                             .isEqualTo(user1.getId())),
                 () -> assertThat(results)
                     .as("Комментарий 1 для user1 (ID: %s) должен присутствовать", comment1User1Event1.getId())
-                    .extracting(CommentDto::getId)
+                    .extracting(CommentAdminDto::getId)
                     .contains(comment1User1Event1.getId()),
                 () -> assertThat(results)
                     .as("Комментарий 2 для user1 (удален) (ID: %s) должен присутствовать", comment3User1Event1Deleted.getId())
-                    .extracting(CommentDto::getId)
+                    .extracting(CommentAdminDto::getId)
                     .contains(comment3User1Event1Deleted.getId())
             );
         }
@@ -308,7 +309,7 @@ class CommentServiceIntegrationTest {
         void getAllCommentsAdmin_withEventIdFilter_shouldReturnEventComments() {
             AdminCommentSearchParams params = AdminCommentSearchParams.builder()
                 .eventId(event1.getId()).build();
-            List<CommentDto> results = commentService.getAllCommentsAdmin(params, 0, 10);
+            List<CommentAdminDto> results = commentService.getAllCommentsAdmin(params, 0, 10);
 
             assertAll(
                 () -> assertThat(results)
@@ -327,7 +328,7 @@ class CommentServiceIntegrationTest {
         void getAllCommentsAdmin_withIsDeletedFalse_shouldReturnNotDeletedComments() {
             AdminCommentSearchParams params = AdminCommentSearchParams.builder().isDeleted(false)
                 .build();
-            List<CommentDto> results = commentService.getAllCommentsAdmin(params, 0, 10);
+            List<CommentAdminDto> results = commentService.getAllCommentsAdmin(params, 0, 10);
 
             assertAll(
                 () -> assertThat(results)
@@ -335,19 +336,19 @@ class CommentServiceIntegrationTest {
                     .hasSize(3),
                 () -> assertThat(results)
                     .as("Удаленный комментарий (comment2 ID: %s) НЕ должен присутствовать в результатах", comment3User1Event1Deleted.getId())
-                    .extracting(CommentDto::getId)
+                    .extracting(CommentAdminDto::getId)
                     .doesNotContain(comment3User1Event1Deleted.getId()),
                 () -> assertThat(results)
                     .as("Комментарий1 (ID: %s) должен присутствовать в результатах", comment1User1Event1.getId())
-                    .extracting(CommentDto::getId)
+                    .extracting(CommentAdminDto::getId)
                     .contains(comment1User1Event1.getId()),
                 () -> assertThat(results)
                     .as("Комментарий3 (ID: %s) должен присутствовать в результатах", comment2User2Event1.getId())
-                    .extracting(CommentDto::getId)
+                    .extracting(CommentAdminDto::getId)
                     .contains(comment2User2Event1.getId()),
                 () -> assertThat(results)
                     .as("Комментарий4 (ID: %s) должен присутствовать в результатах", comment4User2Event2.getId())
-                    .extracting(CommentDto::getId)
+                    .extracting(CommentAdminDto::getId)
                     .contains(comment4User2Event2.getId()),
                 () -> assertThat(results)
                     .as("Все полученные экземпляры CommentDto должны иметь ненулевой ID типа Long")
@@ -369,7 +370,7 @@ class CommentServiceIntegrationTest {
         void getAllCommentsAdmin_withIsDeletedTrue_shouldReturnDeletedComments() {
             AdminCommentSearchParams params = AdminCommentSearchParams.builder().isDeleted(true)
                 .build();
-            List<CommentDto> results = commentService.getAllCommentsAdmin(params, 0, 10);
+            List<CommentAdminDto> results = commentService.getAllCommentsAdmin(params, 0, 10);
 
             assertAll(
                 () -> assertThat(results)
@@ -380,7 +381,7 @@ class CommentServiceIntegrationTest {
                     .hasFieldOrPropertyWithValue("id", comment3User1Event1Deleted.getId())
             );
 
-            CommentDto resultDto = results.getFirst();
+            CommentAdminDto resultDto = results.getFirst();
             assertThat(findCommentInDb(resultDto.getId()).isDeleted())
                 .as("Комментарий %s (проверка БД) должен быть помечен как удаленный", resultDto.getId())
                 .isTrue();
@@ -391,14 +392,14 @@ class CommentServiceIntegrationTest {
         void getAllCommentsAdmin_withCombinedFilters_shouldReturnMatchingComments() {
             AdminCommentSearchParams params = AdminCommentSearchParams.builder()
                 .userId(user1.getId()).eventId(event1.getId()).isDeleted(false).build();
-            List<CommentDto> results = commentService.getAllCommentsAdmin(params, 0, 10);
+            List<CommentAdminDto> results = commentService.getAllCommentsAdmin(params, 0, 10);
 
             assertAll(
                 () -> assertThat(results)
                     .as("Должен вернуть ровно 1 комментарий по заданным фильтрам")
                     .hasSize(1),
                 () -> {
-                    CommentDto resultDto = results.getFirst();
+                    CommentAdminDto resultDto = results.getFirst();
                     assertThat(resultDto)
                         .as("Возвращенный комментарий (ID: %s) должен соответствовать comment1User1Event1", resultDto.getId())
                         .hasFieldOrPropertyWithValue("id", comment1User1Event1.getId())
@@ -410,7 +411,7 @@ class CommentServiceIntegrationTest {
                 }
             );
 
-            CommentDto resultDtoForDbCheck = results.getFirst();
+            CommentAdminDto resultDtoForDbCheck = results.getFirst();
             assertThat(findCommentInDb(resultDtoForDbCheck.getId()).isDeleted())
                 .as("Комментарий %s (проверка БД) не должен быть помечен как удаленный", resultDtoForDbCheck.getId())
                 .isFalse();
@@ -421,7 +422,7 @@ class CommentServiceIntegrationTest {
         void getAllCommentsAdmin_whenNoMatch_shouldReturnEmptyList() {
             AdminCommentSearchParams params = AdminCommentSearchParams.builder().userId(999L)
                 .build();
-            List<CommentDto> results = commentService.getAllCommentsAdmin(params, 0, 10);
+            List<CommentAdminDto> results = commentService.getAllCommentsAdmin(params, 0, 10);
 
             assertThat(results).isEmpty();
         }


### PR DESCRIPTION
## Описание

Данный Pull Request улучшает административные эндпоинты для работы с комментариями путем введения специализированного DTO `CommentAdminDto`, который включает информацию о статусе "мягкого" удаления комментария (`isDeleted`).

### Проблема, которую решает PR:

Ранее административные API для комментариев использовали общий `CommentDto`, который не содержал поля `isDeleted`. Это не позволяло администраторам при просмотре списка комментариев или при восстановлении комментария видеть его актуальный статус удаления, что усложняло модерацию.

### Ключевые изменения:

1.  **Новый DTO `CommentAdminDto.java`:**
    *   Создан `CommentAdminDto`, включающий все поля из `CommentDto` и дополнительное поле `private Boolean isDeleted;`.

2.  **Обновление `CommentMapper.java`:**
    *   Добавлены новые методы `toAdminDto(Comment comment)` и `toAdminDtoList(List<Comment> comments)` для маппинга сущности `Comment` в `CommentAdminDto`.
    *   Эти методы корректно мапят все поля, включая `isDeleted`.

3.  **Обновление `CommentService` (интерфейс и реализация `CommentServiceImpl`):**
    *   Методы, предназначенные для администраторов и возвращающие информацию о комментариях, обновлены для использования `CommentAdminDto`:
        *   `getAllCommentsAdmin(...)` теперь возвращает `List<CommentAdminDto>`.
        *   `restoreCommentByAdmin(...)` теперь возвращает `CommentAdminDto`.

4.  **Обновление `AdminCommentController.java`:**
    *   Эндпоинты `GET /admin/comments` и `PATCH /admin/comments/{commentId}/restore` теперь возвращают `List<CommentAdminDto>` и `CommentAdminDto` соответственно.

5.  **Тестирование:**
    *   Обновлены/добавлены юнит-тесты для `CommentMapper` для проверки маппинга в `CommentAdminDto`.
    *   Обновлены/добавлены юнит-тесты для `CommentServiceImpl` и `AdminCommentController` для проверки корректной работы с новым DTO и возврата поля `isDeleted`.
    *   Обновлены/добавлены интеграционные тесты для проверки, что админские эндпоинты корректно возвращают `isDeleted`.